### PR TITLE
vx_alloc_dev_mem(): Start allocating at 0x10 instead of 0x0

### DIFF
--- a/driver/include/vortex.h
+++ b/driver/include/vortex.h
@@ -23,7 +23,9 @@ typedef void* vx_buffer_h;
 #define VX_CAPS_KERNEL_BASE_ADDR  0x7
 
 #define CACHE_BLOCK_SIZE 64
-#define ALLOC_BASE_ADDR  0x00000000
+// Choose some starting address >0x0 to avoid making NULL a valid
+// pointer value
+#define ALLOC_BASE_ADDR  0x00000010
 #define LOCAL_MEM_SIZE   0xffffffff
 
 // open the device and connect to it


### PR DESCRIPTION
Hi Blaise, this is a pretty small change, but I spent a while last night trying to debug my kernel, only to find out I'd forgotten that some pointer to 0 was actually valid. Like I had a `NULL` check in my code but it didn't behave as I expected because my data pointer happened to actually be to address `0x0`.

What do you think about this tiny change to have `vx_alloc_dev_mem()` allocate from address `0x10` instead of `0x0` to (hopefully) avoid confusing future programmers? I chose `0x10` pretty arbitrarily, but I didn't want to do something like `0x1` in case that would screw up any word alignment anywhere.

### Testing

 * Before (at `HEAD` for `staging`, aka 2216a3059dc8002b7717a4d14f39bcd9902561cb right now). Note that `dev_src0` is located at address `0x0`:
   * `demo` driver test with rtlsim driver: 

     ```
     allocate device memory
     dev_src0=0
     dev_src1=1000
     dev_dst=2000
     ```
   * `demo` driver test with simx driver: 

     ```
     ...
     allocate device memory
     dev_src0=0
     dev_src1=1000
     dev_dst=2000
     ...
     ```

 * After (this commit):
   * `demo` driver test with rtlsim driver: 

     ```
     ...
     allocate device memory
     dev_src0=10
     dev_src1=1010
     dev_dst=2010
     ...
     ```
   * `demo` driver test with simx driver: 

     ```
     ...
     allocate device memory
     dev_src0=10
     dev_src1=1010
     dev_dst=2010
     ...
     ```