### PR TITLE
Change in-use bank id with a single bank

### DIFF
--- a/sim/simx/sharedmem.h
+++ b/sim/simx/sharedmem.h
@@ -62,10 +62,18 @@ public:
                 core_req.addr, bank_sel_addr_start_, bank_sel_addr_end_);
 
             // bank conflict check
-            if (in_used_banks.at(bank_id))
+	    // with 1 bank, set bank_id = 0 if used
+	    if ((config_.num_banks == 1) && (in_used_banks.at(bank_id-1)))
+			continue;
+
+	    if (config_.num_banks == 1)
+            	in_used_banks.at(bank_id-1) = true;
+
+            if ((config_.num_banks > 1) && (in_used_banks.at(bank_id)))
                 continue;
 
-            in_used_banks.at(bank_id) = true;
+	    if (config_.num_banks > 1)
+            	in_used_banks.at(bank_id) = true;
 
             if (!core_req.write || config_.write_reponse) {
                 // send response


### PR DESCRIPTION
Fix for issue #82 

In case the number of banks is configured as 1, the `in_use_banks` vector is of size 1. If the first bank is in use, the vector's member at index 1 is being set. 
The fix changes this to set the member at index 0, since with size 1, only the member at index 0 has been set.