### PR TITLE
Fix for tool chain install script

### DIFF
--- a/ci/toolchain_install.sh
+++ b/ci/toolchain_install.sh
@@ -80,7 +80,7 @@ llvm-vortex()
 llvm-pocl()
 {
     case $OSDIR in
-    "centos/7") parts=$(eval echo {a..g}) ;;
+    "centos/7") parts=$(eval echo {a..b}) ;;
     *)          parts=$(eval echo {a..b}) ;;
     esac
     echo $parts

--- a/ci/toolchain_install.sh
+++ b/ci/toolchain_install.sh
@@ -80,7 +80,7 @@ llvm-vortex()
 llvm-pocl()
 {
     case $OSDIR in
-    "centos/7") parts=$(eval echo {a..b}) ;;
+    "centos/7") parts=$(eval echo {a..g}) ;;
     *)          parts=$(eval echo {a..b}) ;;
     esac
     echo $parts


### PR DESCRIPTION
**Issue**
The prebuilt llvm-pocl (Centos 7 version) is consists of 7 different compressed file (from partaa,partab ..... partag). But the ci/toolchain_install.sh only downloads parts a and b which leads to an error.

**Solution**
The solution is to modify the script ci/toolchain_install.sh script's llvm-pocl subroutine/function to the following

```
llvm-pocl()
{
    case $OSDIR in
   "centos/7") parts=$(eval echo {a..g}) ;;
    *)          parts=$(eval echo {a..b}) ;;
    esac
    echo $parts
    rm -f llvm-pocl.tar.bz2.parta*
    for x in $parts
    do
        wget $REPOSITORY/llvm-pocl/$OSDIR/llvm-pocl.tar.bz2.parta$x
    done
```

The change is in the 4th line. Changing from
<s>"centos/7") parts=$(eval echo {a..b}) ;;</s>
to
"centos/7") parts=$(eval echo {a..g}) ;;