### PR TITLE
LSU exe_unit update for multi-word req

### DIFF
--- a/sim/simx/exe_unit.cpp
+++ b/sim/simx/exe_unit.cpp
@@ -148,9 +148,10 @@ void LsuUnit::tick() {
             auto& output = Outputs.at(iw);
             output.send(trace, 1);
             pending_rd_reqs_.release(mem_rsp.tag);
+            smem_rsp_port.pop();  
+            --pending_loads_;
         } 
-        smem_rsp_port.pop();  
-        --pending_loads_;
+        
     }
 
     if (fence_lock_) {


### PR DESCRIPTION
For multi word requests per thread, the smem_rsp_port pops the load without servicing all requests. This leaves pending_rd_reqs_ in queue and count keeps getting reset to the original requested number of words. Since entry.count never reaches 0, the read request is never released and the pipeline hangs.