### PR TITLE
toolchain_install.sh.in fix: must pre-create $TOOLDIR

### DIFF
--- a/ci/toolchain_install.sh.in
+++ b/ci/toolchain_install.sh.in
@@ -34,6 +34,7 @@ riscv32()
     done
     cat riscv32-gnu-toolchain.tar.bz2.parta* > riscv32-gnu-toolchain.tar.bz2
     tar -xvf riscv32-gnu-toolchain.tar.bz2
+    mkdir -p $TOOLDIR
     cp -r riscv32-gnu-toolchain $TOOLDIR
     rm -f riscv32-gnu-toolchain.tar.bz2*
     rm -rf riscv32-gnu-toolchain
@@ -52,6 +53,7 @@ riscv64()
     done
     cat riscv64-gnu-toolchain.tar.bz2.parta* > riscv64-gnu-toolchain.tar.bz2
     tar -xvf riscv64-gnu-toolchain.tar.bz2
+    mkdir -p $TOOLDIR
     cp -r riscv64-gnu-toolchain $TOOLDIR
     rm -f riscv64-gnu-toolchain.tar.bz2*
     rm -rf riscv64-gnu-toolchain
@@ -71,6 +73,7 @@ llvm()
     done
     cat llvm-vortex2.tar.bz2.parta* > llvm-vortex2.tar.bz2
     tar -xvf llvm-vortex2.tar.bz2
+    mkdir -p $TOOLDIR
     cp -r llvm-vortex $TOOLDIR
     rm -f llvm-vortex2.tar.bz2*
     rm -rf llvm-vortex
@@ -81,6 +84,7 @@ libc32()
     wget $REPOSITORY/libc32/libc32.tar.bz2
     tar -xvf libc32.tar.bz2
     rm -f libc32.tar.bz2
+    mkdir -p $TOOLDIR
     cp -r libc32 $TOOLDIR
     rm -rf libc32
 }
@@ -90,6 +94,7 @@ libc64()
     wget $REPOSITORY/libc64/libc64.tar.bz2
     tar -xvf libc64.tar.bz2
     rm -f libc64.tar.bz2
+    mkdir -p $TOOLDIR
     cp -r libc64 $TOOLDIR
     rm -rf libc64
 }
@@ -99,6 +104,7 @@ libcrt32()
     wget $REPOSITORY/libcrt32/libcrt32.tar.bz2
     tar -xvf libcrt32.tar.bz2
     rm -f libcrt32.tar.bz2
+    mkdir -p $TOOLDIR
     cp -r libcrt32 $TOOLDIR
     rm -rf libcrt32
 }
@@ -108,6 +114,7 @@ libcrt64()
     wget $REPOSITORY/libcrt64/libcrt64.tar.bz2
     tar -xvf libcrt64.tar.bz2
     rm -f libcrt64.tar.bz2
+    mkdir -p $TOOLDIR
     cp -r libcrt64 $TOOLDIR
     rm -rf libcrt64
 }
@@ -117,6 +124,7 @@ libc32()
     wget $REPOSITORY/libc32/libc32.tar.bz2
     tar -xvf libc32.tar.bz2
     rm -f libc32.tar.bz2
+    mkdir -p $TOOLDIR
     cp -r libc32 $TOOLDIR
     rm -rf libc32
 }
@@ -126,6 +134,7 @@ libc64()
     wget $REPOSITORY/libc64/libc64.tar.bz2
     tar -xvf libc64.tar.bz2
     rm -f libc64.tar.bz2
+    mkdir -p $TOOLDIR
     cp -r libc64 $TOOLDIR
     rm -rf libc64
 }
@@ -135,6 +144,7 @@ pocl()
     wget $REPOSITORY/pocl/$OSDIR/pocl2.tar.bz2
     tar -xvf pocl2.tar.bz2
     rm -f pocl2.tar.bz2
+    mkdir -p $TOOLDIR
     cp -r pocl $TOOLDIR
     rm -rf pocl
 }
@@ -143,6 +153,7 @@ verilator()
 {
     wget $REPOSITORY/verilator/$OSDIR/verilator.tar.bz2
     tar -xvf verilator.tar.bz2
+    mkdir -p $TOOLDIR
     cp -r verilator $TOOLDIR
     rm -f verilator.tar.bz2
     rm -rf verilator
@@ -153,6 +164,7 @@ sv2v()
     wget $REPOSITORY/sv2v/$OSDIR/sv2v.tar.bz2
     tar -xvf sv2v.tar.bz2
     rm -f sv2v.tar.bz2
+    mkdir -p $TOOLDIR
     cp -r sv2v $TOOLDIR
     rm -rf sv2v
 }
@@ -171,6 +183,7 @@ yosys()
     done
     cat yosys.tar.bz2.parta* > yosys.tar.bz2
     tar -xvf yosys.tar.bz2
+    mkdir -p $TOOLDIR
     cp -r yosys $TOOLDIR
     rm -f yosys.tar.bz2*
     rm -rf yosys


### PR DESCRIPTION
For example, with `--all` argument, if TOOLDIR does not exists, `cp -r pocl $TOOLDIR` would essentially rename `pocl` to `$TOOLDIR`, instead of moving the `pocl` direcotry to `$TOOLDIR` itself. I.e. the structure will be `tools/runtime` and `tools/compiler` instead of `tools/pocl/runtime` and `tools/pocl/compiler`.

See for example error reported at
https://github.com/vortexgpgpu/vortex/pull/123