### PR TITLE
Implement tensor load

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,10 @@ deps/*
 *.depend
 # Third party
 third_party/*
+# Sim
+sim/*
+# Runtime
+runtime/*
 # Shared
 *.so
 # Others

--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,6 @@ deps/*
 *.o
 *.a
 *.cache
-*.vh
 *.depend
 # Third party
 third_party/*
@@ -27,5 +26,6 @@ third_party/*
 
 .python-version
 compile_commands.json
-run.log
 trace.vcd
+*.log
+*.gtkw

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,31 @@
+# Executables
+## Ignore all
+*
+## Unignore all with extensions
+!*.*
+## Unignore all dirs
+!*/
+# CI
+ci/*
+# Dependencies
+deps/*
+# Object files
+*.o
+*.a
+*.cache
+*.vh
+*.depend
+# Third party
+third_party/*
+# Shared
+*.so
+# Others
+*.dump
+*.pocl
+*.bin
+*.elf
+
+.python-version
+compile_commands.json
+run.log
+trace.vcd

--- a/hw/.rules.verible_lint
+++ b/hw/.rules.verible_lint
@@ -1,0 +1,5 @@
+parameter-name-style=localparam_style:ALL_CAPS
+-always-comb
+-explicit-parameter-storage-type
+-no-trailing-spaces
+-generate-label

--- a/hw/rtl/VX_define.vh
+++ b/hw/rtl/VX_define.vh
@@ -200,7 +200,6 @@
 `define INST_LSU_BITS        4
 `define INST_LSU_FMT(op)     op[2:0]
 `define INST_LSU_WSIZE(op)   op[1:0]
-`define INST_LSU_IS_FENCE(op) (op[3:2] == 3)
 
 `define INST_FENCE_BITS      1
 `define INST_FENCE_D         1'h0

--- a/hw/rtl/VX_define.vh
+++ b/hw/rtl/VX_define.vh
@@ -195,7 +195,7 @@
 `define INST_LSU_SH          4'b1001
 `define INST_LSU_SW          4'b1010
 `define INST_LSU_SD          4'b1011 // new for RV64I SD
-`define INST_MLOAD           4'b1100 // Mod2 adding op-type
+`define INST_LSU_MLOAD       4'b1110 // Mod2 adding op-type
 `define INST_LSU_FENCE       4'b1111
 `define INST_LSU_BITS        4
 `define INST_LSU_FMT(op)     op[2:0]
@@ -425,7 +425,7 @@
     tid, \
     data.rs1_data, \
     data.rs2_data, \
-    data.rs3_data}
+    data.rs3_data }
 
 ///////////////////////////////////////////////////////////////////////////////
 

--- a/hw/rtl/VX_define.vh
+++ b/hw/rtl/VX_define.vh
@@ -1,10 +1,10 @@
 // Copyright © 2019-2023
-// 
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 // http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -90,10 +90,10 @@
 
 `define INST_FL         7'b0000111 // float load instruction
 `define INST_FS         7'b0100111 // float store  instruction
-`define INST_FMADD      7'b1000011  
+`define INST_FMADD      7'b1000011
 `define INST_FMSUB      7'b1000111
 `define INST_FNMSUB     7'b1001011
-`define INST_FNMADD     7'b1001111 
+`define INST_FNMADD     7'b1001111
 `define INST_FCI        7'b1010011 // float common instructions
 
 // Custom extension opcodes
@@ -143,8 +143,8 @@
 
 `define INST_BR_EQ           4'b0000
 `define INST_BR_NE           4'b0010
-`define INST_BR_LTU          4'b0100 
-`define INST_BR_GEU          4'b0110 
+`define INST_BR_LTU          4'b0100
+`define INST_BR_GEU          4'b0110
 `define INST_BR_LT           4'b0101
 `define INST_BR_GE           4'b0111
 `define INST_BR_JAL          4'b1000
@@ -184,17 +184,18 @@
 `define INST_FMT_HU          3'b101
 `define INST_FMT_WU          3'b110
 
-`define INST_LSU_LB          4'b0000 
+`define INST_LSU_LB          4'b0000
 `define INST_LSU_LH          4'b0001
 `define INST_LSU_LW          4'b0010
 `define INST_LSU_LD          4'b0011 // new for RV64I LD
 `define INST_LSU_LBU         4'b0100
 `define INST_LSU_LHU         4'b0101
 `define INST_LSU_LWU         4'b0110 // new for RV64I LWU
-`define INST_LSU_SB          4'b1000 
+`define INST_LSU_SB          4'b1000
 `define INST_LSU_SH          4'b1001
 `define INST_LSU_SW          4'b1010
 `define INST_LSU_SD          4'b1011 // new for RV64I SD
+`define INST_MLOAD           4'b1100 // Mod2 adding op-type
 `define INST_LSU_FENCE       4'b1111
 `define INST_LSU_BITS        4
 `define INST_LSU_FMT(op)     op[2:0]
@@ -205,9 +206,9 @@
 `define INST_FENCE_D         1'h0
 `define INST_FENCE_I         1'h1
 
-`define INST_FPU_ADD         4'b0000 
-`define INST_FPU_SUB         4'b0001 
-`define INST_FPU_MUL         4'b0010 
+`define INST_FPU_ADD         4'b0000
+`define INST_FPU_SUB         4'b0001
+`define INST_FPU_MUL         4'b0010
 `define INST_FPU_DIV         4'b0011
 `define INST_FPU_SQRT        4'b0100
 `define INST_FPU_CMP         4'b0101 // mod: LE=0, LT=1, EQ=2
@@ -217,9 +218,9 @@
 `define INST_FPU_F2U         4'b1001
 `define INST_FPU_I2F         4'b1010
 `define INST_FPU_U2F         4'b1011
-`define INST_FPU_MADD        4'b1100 
-`define INST_FPU_MSUB        4'b1101   
-`define INST_FPU_NMSUB       4'b1110   
+`define INST_FPU_MADD        4'b1100
+`define INST_FPU_MSUB        4'b1101
+`define INST_FPU_NMSUB       4'b1110
 `define INST_FPU_NMADD       4'b1111
 `define INST_FPU_BITS        4
 `define INST_FPU_IS_W(mod)   (mod[4])
@@ -227,7 +228,7 @@
 `define INST_FPU_IS_MVXW(op, mod) (op == `INST_FPU_MISC && mod == 4)
 
 `define INST_SFU_TMC         4'h0
-`define INST_SFU_WSPAWN      4'h1 
+`define INST_SFU_WSPAWN      4'h1
 `define INST_SFU_SPLIT       4'h2
 `define INST_SFU_JOIN        4'h3
 `define INST_SFU_BAR         4'h4
@@ -259,7 +260,6 @@
 
 `define CACHE_MEM_TAG_WIDTH(mshr_size, num_banks) \
         (`CLOG2(mshr_size) + `CLOG2(num_banks) + `NC_TAG_BITS)
-        
 `define CACHE_NC_BYPASS_TAG_WIDTH(num_reqs, line_size, word_size, tag_width) \
         (`CLOG2(num_reqs) + `CLOG2(line_size / word_size) + tag_width)
 
@@ -272,7 +272,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 
 `define CACHE_CLUSTER_CORE_ARB_TAG(tag_width, num_inputs, num_caches) \
-        (tag_width + `ARB_SEL_BITS(num_inputs, `UP(num_caches)))  
+        (tag_width + `ARB_SEL_BITS(num_inputs, `UP(num_caches)))
 
 `define CACHE_CLUSTER_MEM_ARB_TAG(tag_width, num_caches) \
         (tag_width + `ARB_SEL_BITS(`UP(num_caches), 1))
@@ -298,7 +298,7 @@
 `define L1_ENABLE
 `endif
 
-`define VX_MEM_BYTEEN_WIDTH     `L3_LINE_SIZE   
+`define VX_MEM_BYTEEN_WIDTH     `L3_LINE_SIZE
 `define VX_MEM_ADDR_WIDTH       (`MEM_ADDR_WIDTH - `CLOG2(`L3_LINE_SIZE))
 `define VX_MEM_DATA_WIDTH       (`L3_LINE_SIZE * 8)
 `define VX_MEM_TAG_WIDTH        L3_MEM_TAG_WIDTH

--- a/hw/rtl/VX_define.vh
+++ b/hw/rtl/VX_define.vh
@@ -195,7 +195,7 @@
 `define INST_LSU_SH          4'b1001
 `define INST_LSU_SW          4'b1010
 `define INST_LSU_SD          4'b1011 // new for RV64I SD
-`define INST_LSU_MLOAD       4'b1110 // Mod2 adding op-type
+`define INST_LSU_MLOAD       4'b1110 // new fow MLOAD
 `define INST_LSU_FENCE       4'b1111
 `define INST_LSU_BITS        4
 `define INST_LSU_FMT(op)     op[2:0]

--- a/hw/rtl/core/VX_alu_unit.sv
+++ b/hw/rtl/core/VX_alu_unit.sv
@@ -25,14 +25,14 @@ module VX_alu_unit #(
     // Outputs
     VX_commit_if.master     commit_if [`ISSUE_WIDTH],
     VX_branch_ctl_if.master branch_ctl_if [`NUM_ALU_BLOCKS]
-);   
+);
 
     `UNUSED_PARAM (CORE_ID)
     localparam BLOCK_SIZE   = `NUM_ALU_BLOCKS;
     localparam NUM_LANES    = `NUM_ALU_LANES;
     localparam PID_BITS     = `CLOG2(`NUM_THREADS / NUM_LANES);
     localparam PID_WIDTH    = `UP(PID_BITS);
-    localparam RSP_ARB_DATAW= `UUID_WIDTH + `NW_WIDTH + NUM_LANES + `XLEN + `NR_BITS + 1 + NUM_LANES * `XLEN + PID_WIDTH + 1 + 1;
+    localparam RSP_ARB_DATAW= `UUID_WIDTH + `NW_WIDTH + NUM_LANES + `XLEN + `NR_BITS + 1 + NUM_LANES * `XLEN + PID_WIDTH + 1 + 1 + `NT_BITS + 1 + 1;
     localparam RSP_ARB_SIZE = 1 + `EXT_M_ENABLED;
     localparam PARTIAL_BW   = (BLOCK_SIZE != `ISSUE_WIDTH) || (NUM_LANES != `NUM_THREADS);
 
@@ -114,13 +114,12 @@ module VX_alu_unit #(
         );       
        
         assign execute_if[block_idx].ready = is_muldiv_op ? mdv_execute_if.ready : int_execute_if.ready;
-
     `else
 
         assign is_muldiv_op = 0;
         assign execute_if[block_idx].ready = int_execute_if.ready;
-
     `endif
+
 
         // send response
 
@@ -150,8 +149,8 @@ module VX_alu_unit #(
                 int_commit_if.data
             }),
             .data_out  (commit_block_if[block_idx].data),
-            .valid_out (commit_block_if[block_idx].valid), 
-            .ready_out (commit_block_if[block_idx].ready),            
+            .valid_out (commit_block_if[block_idx].valid),
+            .ready_out (commit_block_if[block_idx].ready),
             `UNUSED_PIN (sel_out)
         );
     end
@@ -168,5 +167,4 @@ module VX_alu_unit #(
         .commit_in_if  (commit_block_if),
         .commit_out_if (commit_if)
     );
-
 endmodule

--- a/hw/rtl/core/VX_alu_unit.sv
+++ b/hw/rtl/core/VX_alu_unit.sv
@@ -32,7 +32,7 @@ module VX_alu_unit #(
     localparam NUM_LANES    = `NUM_ALU_LANES;
     localparam PID_BITS     = `CLOG2(`NUM_THREADS / NUM_LANES);
     localparam PID_WIDTH    = `UP(PID_BITS);
-    localparam RSP_ARB_DATAW= `UUID_WIDTH + `NW_WIDTH + NUM_LANES + `XLEN + `NR_BITS + 1 + NUM_LANES * `XLEN + PID_WIDTH + 1 + 1;
+    localparam RSP_ARB_DATAW= `UUID_WIDTH + `NW_WIDTH + NUM_LANES + `XLEN + `NR_BITS + 1 + NUM_LANES * `XLEN + PID_WIDTH + 1 + 1 + 1;
     localparam RSP_ARB_SIZE = 1 + `EXT_M_ENABLED;
     localparam PARTIAL_BW   = (BLOCK_SIZE != `ISSUE_WIDTH) || (NUM_LANES != `NUM_THREADS);
 

--- a/hw/rtl/core/VX_alu_unit.sv
+++ b/hw/rtl/core/VX_alu_unit.sv
@@ -32,7 +32,7 @@ module VX_alu_unit #(
     localparam NUM_LANES    = `NUM_ALU_LANES;
     localparam PID_BITS     = `CLOG2(`NUM_THREADS / NUM_LANES);
     localparam PID_WIDTH    = `UP(PID_BITS);
-    localparam RSP_ARB_DATAW= `UUID_WIDTH + `NW_WIDTH + NUM_LANES + `XLEN + `NR_BITS + 1 + NUM_LANES * `XLEN + PID_WIDTH + 1 + 1 + `NT_BITS + 1 + 1;
+    localparam RSP_ARB_DATAW= `UUID_WIDTH + `NW_WIDTH + NUM_LANES + `XLEN + `NR_BITS + 1 + NUM_LANES * `XLEN + PID_WIDTH + 1 + 1;
     localparam RSP_ARB_SIZE = 1 + `EXT_M_ENABLED;
     localparam PARTIAL_BW   = (BLOCK_SIZE != `ISSUE_WIDTH) || (NUM_LANES != `NUM_THREADS);
 

--- a/hw/rtl/core/VX_commit.sv
+++ b/hw/rtl/core/VX_commit.sv
@@ -36,7 +36,7 @@ module VX_commit import VX_gpu_pkg::*; #(
     output wire [`NUM_REGS-1:0][`XLEN-1:0] sim_wb_value
 );
     `UNUSED_PARAM (CORE_ID)
-    localparam DATAW = `UUID_WIDTH + `NW_WIDTH + `NUM_THREADS + `XLEN + 1 + `NR_BITS + `NUM_THREADS * `XLEN + 1 + 1 + 1;
+    localparam DATAW = `UUID_WIDTH + `NW_WIDTH + `NUM_THREADS + `XLEN + 1 + `NR_BITS + `NUM_THREADS * `XLEN + 1 + 1 + 1 + `NT_BITS + 1 + 1;
     localparam COMMIT_SIZEW = `CLOG2(`NUM_THREADS + 1);
     localparam COMMIT_ALL_SIZEW = COMMIT_SIZEW + `ISSUE_WIDTH - 1;
 
@@ -98,7 +98,6 @@ module VX_commit import VX_gpu_pkg::*; #(
     end
 
     // CSRs update
-    
     wire [`ISSUE_WIDTH-1:0][COMMIT_SIZEW-1:0] commit_size, commit_size_r;
     wire [COMMIT_ALL_SIZEW-1:0] commit_size_all_r, commit_size_all_rr;
     wire commit_fire_any, commit_fire_any_r, commit_fire_any_rr;
@@ -174,17 +173,18 @@ module VX_commit import VX_gpu_pkg::*; #(
 
     for (genvar i = 0; i < `ISSUE_WIDTH; ++i) begin
         assign writeback_if[i].valid     = commit_if[i].valid && commit_if[i].data.wb;
-        assign writeback_if[i].data.uuid = commit_if[i].data.uuid; 
+        assign writeback_if[i].data.uuid = commit_if[i].data.uuid;
         assign writeback_if[i].data.wis  = wid_to_wis(commit_if[i].data.wid);
-        assign writeback_if[i].data.PC   = commit_if[i].data.PC; 
-        assign writeback_if[i].data.tmask= commit_if[i].data.tmask; 
-        assign writeback_if[i].data.rd   = commit_if[i].data.rd; 
-        assign writeback_if[i].data.data = commit_if[i].data.data; 
-        assign writeback_if[i].data.sop  = commit_if[i].data.sop; 
+        assign writeback_if[i].data.PC   = commit_if[i].data.PC;
+        assign writeback_if[i].data.tmask= commit_if[i].data.tmask;
+        assign writeback_if[i].data.rd   = commit_if[i].data.rd;
+        assign writeback_if[i].data.data = commit_if[i].data.data;
+        assign writeback_if[i].data.sop  = commit_if[i].data.sop;
         assign writeback_if[i].data.eop  = commit_if[i].data.eop;
+        assign writeback_if[i].data.microop_id  = commit_if[i].data.microop_id;
+        assign writeback_if[i].data.is_microop  = commit_if[i].data.is_microop;
         assign commit_if[i].ready = 1'b1; // writeback has no backpressure
     end
-    
     // simulation helper signal to get RISC-V tests Pass/Fail status
     reg [`NUM_REGS-1:0][`XLEN-1:0] sim_wb_value_r;
     always @(posedge clk) begin
@@ -193,7 +193,7 @@ module VX_commit import VX_gpu_pkg::*; #(
         end
     end
     assign sim_wb_value = sim_wb_value_r;
-    
+
 `ifdef DBG_TRACE_CORE_PIPELINE
     for (genvar i = 0; i < `ISSUE_WIDTH; ++i) begin
         always @(posedge clk) begin
@@ -205,7 +205,7 @@ module VX_commit import VX_gpu_pkg::*; #(
             if (lsu_commit_if[i].valid && lsu_commit_if[i].ready) begin
                 `TRACE(1, ("%d: core%0d-commit: wid=%0d, PC=0x%0h, ex=LSU, tmask=%b, wb=%0d, rd=%0d, sop=%b, eop=%b, data=", $time, CORE_ID, lsu_commit_if[i].data.wid, lsu_commit_if[i].data.PC, lsu_commit_if[i].data.tmask, lsu_commit_if[i].data.wb, lsu_commit_if[i].data.rd, lsu_commit_if[i].data.sop, lsu_commit_if[i].data.eop));
                 `TRACE_ARRAY1D(1, lsu_commit_if[i].data.data, `NUM_THREADS);
-                `TRACE(1, (" (#%0d)\n", lsu_commit_if[i].data.uuid));
+                `TRACE(1, (" microop_id=%b is_microop=%b (#%0d)\n",  lsu_commit_if[i].data.microop_id, lsu_commit_if[i].data.is_microop, lsu_commit_if[i].data.uuid));
             end
         `ifdef EXT_F_ENABLE
             if (fpu_commit_if[i].valid && fpu_commit_if[i].ready) begin

--- a/hw/rtl/core/VX_commit.sv
+++ b/hw/rtl/core/VX_commit.sv
@@ -36,13 +36,19 @@ module VX_commit import VX_gpu_pkg::*; #(
     output wire [`NUM_REGS-1:0][`XLEN-1:0] sim_wb_value
 );
     `UNUSED_PARAM (CORE_ID)
-    localparam DATAW = `UUID_WIDTH + `NW_WIDTH + `NUM_THREADS + `XLEN + 1 + `NR_BITS + `NUM_THREADS * `XLEN + 1 + 1 + 1;
+    localparam DATAW = `UUID_WIDTH + `NW_WIDTH + `NUM_THREADS + `XLEN + 1 + `NR_BITS + `NUM_THREADS * `XLEN + 1 + 1 + 1 + 1;
     localparam COMMIT_SIZEW = `CLOG2(`NUM_THREADS + 1);
     localparam COMMIT_ALL_SIZEW = COMMIT_SIZEW + `ISSUE_WIDTH - 1;
 
     // commit arbitration
 
     VX_commit_if commit_if[`ISSUE_WIDTH]();
+
+    VX_commit_if      alu_commit_if_tmp [`ISSUE_WIDTH]();
+    VX_commit_if      sfu_commit_if_tmp [`ISSUE_WIDTH]();
+`ifdef EXT_F_ENABLE
+    VX_commit_if      fpu_commit_if_tmp [`ISSUE_WIDTH]();
+`endif
 
     wire [`ISSUE_WIDTH-1:0] commit_fire;
     wire [`ISSUE_WIDTH-1:0][`NW_WIDTH-1:0] commit_wid;
@@ -52,6 +58,14 @@ module VX_commit import VX_gpu_pkg::*; #(
     for (genvar i = 0; i < `ISSUE_WIDTH; ++i) begin
 
         `RESET_RELAY (arb_reset, reset);
+
+        assign sfu_commit_if_tmp[i].data = sfu_commit_if[i].data;
+        assign alu_commit_if_tmp[i].data = alu_commit_if[i].data;
+        assign fpu_commit_if_tmp[i].data = fpu_commit_if[i].data;
+
+        assign alu_commit_if_tmp[i].data.true_eop = 1'b1;
+        assign fpu_commit_if_tmp[i].data.true_eop = 1'b1;
+        assign sfu_commit_if_tmp[i].data.true_eop = 1'b1;
 
         VX_stream_arb #(
             .NUM_INPUTS (`NUM_EX_UNITS),
@@ -75,15 +89,15 @@ module VX_commit import VX_gpu_pkg::*; #(
                 fpu_commit_if[i].ready,
             `endif
                 alu_commit_if[i].ready,
-                lsu_commit_if[i].ready                
+                lsu_commit_if[i].ready
             }),
             .data_in   ({
-                sfu_commit_if[i].data,
+                sfu_commit_if_tmp[i].data,
             `ifdef EXT_F_ENABLE
-                fpu_commit_if[i].data,
+                fpu_commit_if_tmp[i].data,
             `endif
-                alu_commit_if[i].data,
-                lsu_commit_if[i].data       
+                alu_commit_if_tmp[i].data,
+                lsu_commit_if[i].data
             }),
             .data_out  (commit_if[i].data),
             .valid_out (commit_if[i].valid),
@@ -159,14 +173,14 @@ module VX_commit import VX_gpu_pkg::*; #(
     wire [`ISSUE_WIDTH-1:0] committed = commit_fire & commit_eop;
 
     VX_pipe_register #(
-        .DATAW  (`ISSUE_WIDTH * (1 + `NW_WIDTH)),
+        .DATAW  (`ISSUE_WIDTH * (1 + `NW_WIDTH) + 1),
         .RESETW (`ISSUE_WIDTH)
     ) committed_pipe_reg (
         .clk      (clk),
         .reset    (reset),
         .enable   (1'b1),
-        .data_in  ({committed, commit_wid}),
-        .data_out ({commit_sched_if.committed, commit_sched_if.committed_wid})
+        .data_in  ({committed, commit_wid, commit_if[0].data.true_eop}),
+        .data_out ({commit_sched_if.committed, commit_sched_if.committed_wid, commit_sched_if.true_eop})
     );
 
     // Writeback

--- a/hw/rtl/core/VX_commit.sv
+++ b/hw/rtl/core/VX_commit.sv
@@ -36,7 +36,7 @@ module VX_commit import VX_gpu_pkg::*; #(
     output wire [`NUM_REGS-1:0][`XLEN-1:0] sim_wb_value
 );
     `UNUSED_PARAM (CORE_ID)
-    localparam DATAW = `UUID_WIDTH + `NW_WIDTH + `NUM_THREADS + `XLEN + 1 + `NR_BITS + `NUM_THREADS * `XLEN + 1 + 1 + 1 + `NT_BITS + 1 + 1;
+    localparam DATAW = `UUID_WIDTH + `NW_WIDTH + `NUM_THREADS + `XLEN + 1 + `NR_BITS + `NUM_THREADS * `XLEN + 1 + 1 + 1;
     localparam COMMIT_SIZEW = `CLOG2(`NUM_THREADS + 1);
     localparam COMMIT_ALL_SIZEW = COMMIT_SIZEW + `ISSUE_WIDTH - 1;
 
@@ -181,8 +181,6 @@ module VX_commit import VX_gpu_pkg::*; #(
         assign writeback_if[i].data.data = commit_if[i].data.data;
         assign writeback_if[i].data.sop  = commit_if[i].data.sop;
         assign writeback_if[i].data.eop  = commit_if[i].data.eop;
-        assign writeback_if[i].data.microop_id  = commit_if[i].data.microop_id;
-        assign writeback_if[i].data.is_microop  = commit_if[i].data.is_microop;
         assign commit_if[i].ready = 1'b1; // writeback has no backpressure
     end
     // simulation helper signal to get RISC-V tests Pass/Fail status
@@ -205,7 +203,7 @@ module VX_commit import VX_gpu_pkg::*; #(
             if (lsu_commit_if[i].valid && lsu_commit_if[i].ready) begin
                 `TRACE(1, ("%d: core%0d-commit: wid=%0d, PC=0x%0h, ex=LSU, tmask=%b, wb=%0d, rd=%0d, sop=%b, eop=%b, data=", $time, CORE_ID, lsu_commit_if[i].data.wid, lsu_commit_if[i].data.PC, lsu_commit_if[i].data.tmask, lsu_commit_if[i].data.wb, lsu_commit_if[i].data.rd, lsu_commit_if[i].data.sop, lsu_commit_if[i].data.eop));
                 `TRACE_ARRAY1D(1, lsu_commit_if[i].data.data, `NUM_THREADS);
-                `TRACE(1, (" microop_id=%b is_microop=%b (#%0d)\n",  lsu_commit_if[i].data.microop_id, lsu_commit_if[i].data.is_microop, lsu_commit_if[i].data.uuid));
+                `TRACE(1, (" (#%0d)\n", lsu_commit_if[i].data.uuid));
             end
         `ifdef EXT_F_ENABLE
             if (fpu_commit_if[i].valid && fpu_commit_if[i].ready) begin

--- a/hw/rtl/core/VX_core.sv
+++ b/hw/rtl/core/VX_core.sv
@@ -1,10 +1,10 @@
 // Copyright © 2019-2023
-// 
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 // http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -17,11 +17,10 @@
 `include "VX_fpu_define.vh"
 `endif
 
-module VX_core import VX_gpu_pkg::*; #( 
+module VX_core import VX_gpu_pkg::*; #(
     parameter CORE_ID = 0
-) (        
+) (
     `SCOPE_IO_DECL
-    
     // Clock
     input wire              clk,
     input wire              reset,
@@ -180,19 +179,17 @@ module VX_core import VX_gpu_pkg::*; #(
         .CORE_ID (CORE_ID)
     ) execute (
         `SCOPE_IO_BIND  (2)
-        
         .clk            (clk),
         .reset          (execute_reset),
 
         .base_dcrs      (base_dcrs),
 
     `ifdef PERF_ENABLE
-        .mem_perf_if    (mem_perf_tmp_if),        
+        .mem_perf_if    (mem_perf_tmp_if),
         .pipeline_perf_if(pipeline_perf_if),
-    `endif 
+    `endif
 
         .dcache_bus_if  (dcache_bus_tmp_if),
-    
     `ifdef EXT_F_ENABLE
         .fpu_dispatch_if(fpu_dispatch_if),
         .fpu_commit_if  (fpu_commit_if),
@@ -200,7 +197,6 @@ module VX_core import VX_gpu_pkg::*; #(
 
         .commit_csr_if  (commit_csr_if),
         .sched_csr_if   (sched_csr_if),
-        
         .alu_dispatch_if(alu_dispatch_if),
         .lsu_dispatch_if(lsu_dispatch_if),
         .sfu_dispatch_if(sfu_dispatch_if),
@@ -213,7 +209,7 @@ module VX_core import VX_gpu_pkg::*; #(
         .sfu_commit_if  (sfu_commit_if),
 
         .sim_ebreak     (sim_ebreak)
-    );    
+    );
 
     VX_commit #(
         .CORE_ID (CORE_ID)
@@ -227,9 +223,7 @@ module VX_core import VX_gpu_pkg::*; #(
         .fpu_commit_if  (fpu_commit_if),
     `endif
         .sfu_commit_if  (sfu_commit_if),
-        
         .writeback_if   (writeback_if),
-        
         .commit_csr_if  (commit_csr_if),
         .commit_sched_if(commit_sched_if),
 
@@ -262,7 +256,7 @@ module VX_core import VX_gpu_pkg::*; #(
 
     wire [`CLOG2(DCACHE_NUM_REQS+1)-1:0] perf_dcache_rd_req_per_cycle;
     wire [`CLOG2(DCACHE_NUM_REQS+1)-1:0] perf_dcache_wr_req_per_cycle;
-    wire [`CLOG2(DCACHE_NUM_REQS+1)-1:0] perf_dcache_rsp_per_cycle;    
+    wire [`CLOG2(DCACHE_NUM_REQS+1)-1:0] perf_dcache_rsp_per_cycle;
 
     wire [1:0] perf_icache_pending_read_cycle;
     wire [`CLOG2(DCACHE_NUM_REQS+1)+1-1:0] perf_dcache_pending_read_cycle;
@@ -293,7 +287,6 @@ module VX_core import VX_gpu_pkg::*; #(
     `POP_COUNT(perf_dcache_rd_req_per_cycle, perf_dcache_rd_req_fire_r);
     `POP_COUNT(perf_dcache_wr_req_per_cycle, perf_dcache_wr_req_fire_r);
     `POP_COUNT(perf_dcache_rsp_per_cycle, perf_dcache_rsp_fire);
-      
     assign perf_icache_pending_read_cycle = perf_icache_req_fire - perf_icache_rsp_fire;
     assign perf_dcache_pending_read_cycle = perf_dcache_rd_req_per_cycle - perf_dcache_rsp_per_cycle;
 
@@ -306,7 +299,6 @@ module VX_core import VX_gpu_pkg::*; #(
             perf_dcache_pending_reads <= $signed(perf_dcache_pending_reads) + `PERF_CTR_BITS'($signed(perf_dcache_pending_read_cycle));
         end
     end
-    
     reg [`PERF_CTR_BITS-1:0] perf_icache_lat;
     reg [`PERF_CTR_BITS-1:0] perf_dcache_lat;
 

--- a/hw/rtl/core/VX_csr_unit.sv
+++ b/hw/rtl/core/VX_csr_unit.sv
@@ -39,7 +39,7 @@ module VX_csr_unit import VX_gpu_pkg::*; #(
     `UNUSED_PARAM (CORE_ID)
     localparam PID_BITS   = `CLOG2(`NUM_THREADS / NUM_LANES);
     localparam PID_WIDTH  = `UP(PID_BITS);
-    localparam DATAW      = `UUID_WIDTH + `NW_WIDTH + NUM_LANES + `XLEN + `NR_BITS + 1 + NUM_LANES * 32 + PID_WIDTH + 1 + 1;
+    localparam DATAW      = `UUID_WIDTH + `NW_WIDTH + NUM_LANES + `XLEN + `NR_BITS + 1 + NUM_LANES * 32 + PID_WIDTH + 1 + 1 + 1;
 
     `UNUSED_VAR (execute_if.data.rs3_data)
     
@@ -166,14 +166,15 @@ module VX_csr_unit import VX_gpu_pkg::*; #(
         .reset     (reset),
         .valid_in  (csr_req_valid),
         .ready_in  (csr_req_ready),
-        .data_in   ({execute_if.data.uuid, execute_if.data.wid, execute_if.data.tmask, execute_if.data.PC, execute_if.data.rd, execute_if.data.wb, csr_read_data, execute_if.data.pid, execute_if.data.sop, execute_if.data.eop}),
-        .data_out  ({commit_if.data.uuid, commit_if.data.wid, commit_if.data.tmask, commit_if.data.PC, commit_if.data.rd, commit_if.data.wb, csr_commit_data, commit_if.data.pid, commit_if.data.sop, commit_if.data.eop}),
+        .data_in   ({execute_if.data.uuid, execute_if.data.wid, execute_if.data.tmask, execute_if.data.PC, execute_if.data.rd, execute_if.data.wb, csr_read_data, execute_if.data.pid, execute_if.data.sop, execute_if.data.eop, 1'b1}),
+        .data_out  ({commit_if.data.uuid, commit_if.data.wid, commit_if.data.tmask, commit_if.data.PC, commit_if.data.rd, commit_if.data.wb, csr_commit_data, commit_if.data.pid, commit_if.data.sop, commit_if.data.eop, commit_if.data.true_eop}),
         .valid_out (commit_if.valid),
         .ready_out (commit_if.ready)
     );
     
     for (genvar i = 0; i < NUM_LANES; ++i) begin
         assign commit_if.data.data[i] = `XLEN'(csr_commit_data[i]);
+        assign commit_if.data.true_eop = 1'b1;
     end
 
 endmodule

--- a/hw/rtl/core/VX_decode.sv
+++ b/hw/rtl/core/VX_decode.sv
@@ -42,7 +42,7 @@ module VX_decode  #(
     VX_decode_sched_if.master decode_sched_if
 );
 
-    localparam DATAW = `UUID_WIDTH + `NW_WIDTH + `NUM_THREADS + `XLEN + `EX_BITS + `INST_OP_BITS + `INST_MOD_BITS + 1 + (`NR_BITS * 4) + `XLEN + 1 + 1;
+    localparam DATAW = `UUID_WIDTH + `NW_WIDTH + `NUM_THREADS + `XLEN + `EX_BITS + `INST_OP_BITS + `INST_MOD_BITS + (`NR_BITS * 4) + `XLEN + 1 + 1 + 1;
 
     `UNUSED_PARAM (CORE_ID)
     `UNUSED_VAR (clk)
@@ -146,7 +146,6 @@ module VX_decode  #(
 `endif
 
     always @(*) begin
-
         ex_type   = '0;
         op_type   = 'x;
         op_mod    = '0;
@@ -505,16 +504,13 @@ module VX_decode  #(
                     default:;
                 endcase
             end
-            `INST_EXT3: begin // Mod3
+            `INST_EXT3: begin
                 case (func3)
                     3'h0: begin
-                        op_type = `INST_OP_BITS'(`INST_MLOAD);
+                        op_type = `INST_OP_BITS'(`INST_LSU_MLOAD);
                         ex_type = `EX_LSU;
-                        // Input addresses
                         `USED_IREG (rs1);
                         `USED_IREG (rs2);
-                        // Output register
-                        use_rd  = 1;
                         `USED_IREG (rd);
                     end
                     default:;

--- a/hw/rtl/core/VX_decode.sv
+++ b/hw/rtl/core/VX_decode.sv
@@ -508,14 +508,14 @@ module VX_decode  #(
             `INST_EXT3: begin // Mod3
                 case (func3)
                     3'h0: begin
-                    op_type = `INST_OP_BITS'(`INST_MLOAD);
-                    ex_type = `EX_LSU;
-                    // Input addresses
-                    `USED_IREG (rs1);
-                    `USED_IREG (rs2);
-                    // Output register
-                    // use_rd  = 1; TODO: is this needed? hint: probably not
-                    `USED_IREG (rd);
+                        op_type = `INST_OP_BITS'(`INST_MLOAD);
+                        ex_type = `EX_LSU;
+                        // Input addresses
+                        `USED_IREG (rs1);
+                        `USED_IREG (rs2);
+                        // Output register
+                        use_rd  = 1;
+                        `USED_IREG (rd);
                     end
                     default:;
                 endcase

--- a/hw/rtl/core/VX_decode.sv
+++ b/hw/rtl/core/VX_decode.sv
@@ -517,6 +517,7 @@ module VX_decode  #(
                     // use_rd  = 1; TODO: is this needed? hint: probably not
                     `USED_IREG (rd);
                     end
+                    default:;
                 endcase
             end
             default:;

--- a/hw/rtl/core/VX_decode.sv
+++ b/hw/rtl/core/VX_decode.sv
@@ -1,10 +1,10 @@
 // Copyright © 2019-2023
-// 
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 // http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -37,7 +37,7 @@ module VX_decode  #(
     // inputs
     VX_fetch_if.slave       fetch_if,
 
-    // outputs      
+    // outputs
     VX_decode_if.master     decode_if,
     VX_decode_sched_if.master decode_sched_if
 );
@@ -47,17 +47,17 @@ module VX_decode  #(
     `UNUSED_PARAM (CORE_ID)
     `UNUSED_VAR (clk)
     `UNUSED_VAR (reset)
-    
-    reg [`EX_BITS-1:0] ex_type;    
-    reg [`INST_OP_BITS-1:0] op_type; 
+
+    reg [`EX_BITS-1:0] ex_type;
+    reg [`INST_OP_BITS-1:0] op_type;
     reg [`INST_MOD_BITS-1:0] op_mod;
     reg [`NR_BITS-1:0] rd_r, rs1_r, rs2_r, rs3_r;
-    reg [`XLEN-1:0] imm;    
+    reg [`XLEN-1:0] imm;
     reg use_rd, use_rs1, use_rs2, use_rs3, use_PC, use_imm;
     reg is_wstall;
 
     wire [31:0] instr = fetch_if.data.instr;
-    wire [6:0] opcode = instr[6:0];  
+    wire [6:0] opcode = instr[6:0];
     wire [1:0] func2  = instr[26:25];
     wire [2:0] func3  = instr[14:12];
     wire [4:0] func5  = instr[31:27];
@@ -85,7 +85,7 @@ module VX_decode  #(
     wire [11:0] iw_imm  = is_itype_sh ? {7'b0, instr[24:20]} : u_12;
 `else
     wire [11:0] i_imm   = is_itype_sh ? {7'b0, instr[24:20]} : u_12;
-`endif    
+`endif
     wire [11:0] s_imm   = {func7, rd};
     wire [12:0] b_imm   = {instr[31], instr[7], instr[30:25], instr[11:8], 1'b0};
     wire [20:0] jal_imm = {instr[31], instr[19:12], instr[20], instr[30:21], 1'b0};
@@ -121,9 +121,9 @@ module VX_decode  #(
     always @(*) begin
         case (u_12)
             12'h000: s_type = `INST_OP_BITS'(`INST_BR_ECALL);
-            12'h001: s_type = `INST_OP_BITS'(`INST_BR_EBREAK);             
-            12'h002: s_type = `INST_OP_BITS'(`INST_BR_URET);                        
-            12'h102: s_type = `INST_OP_BITS'(`INST_BR_SRET);                        
+            12'h001: s_type = `INST_OP_BITS'(`INST_BR_EBREAK);
+            12'h002: s_type = `INST_OP_BITS'(`INST_BR_URET);
+            12'h102: s_type = `INST_OP_BITS'(`INST_BR_SRET);
             12'h302: s_type = `INST_OP_BITS'(`INST_BR_MRET);
             default: s_type = 'x;
         endcase
@@ -163,7 +163,7 @@ module VX_decode  #(
         use_rs3   = 0;
         is_wstall = 0;
 
-        case (opcode)            
+        case (opcode)
             `INST_I: begin
                 ex_type = `EX_ALU;
                 op_type = `INST_OP_BITS'(r_type);
@@ -173,17 +173,17 @@ module VX_decode  #(
                 `USED_IREG (rd);
                 `USED_IREG (rs1);
             end
-            `INST_R: begin 
+            `INST_R: begin
                 ex_type = `EX_ALU;
             `ifdef EXT_M_ENABLE
                 if (func7[0]) begin
                     op_type = `INST_OP_BITS'(m_type);
                     op_mod[1] = 1;
-                end else 
+                end else
             `endif
                 begin
                     op_type = `INST_OP_BITS'(r_type);
-                end          
+                end
                 use_rd = 1;
                 `USED_IREG (rd);
                 `USED_IREG (rs1);
@@ -203,12 +203,12 @@ module VX_decode  #(
             end
             `INST_R_W: begin
                 ex_type = `EX_ALU;
-            `ifdef EXT_M_ENABLE                
+            `ifdef EXT_M_ENABLE
                 if (func7[0]) begin
                     // MULW, DIVW, DIVUW, REMW, REMUW
                     op_type = `INST_OP_BITS'(m_type);
-                    op_mod[1] = 1;                    
-                end else 
+                    op_mod[1] = 1;
+                end else
             `endif
                 begin
                     // ADDW, SUBW, SLLW, SRLW, SRAW
@@ -221,7 +221,7 @@ module VX_decode  #(
                 `USED_IREG (rs2);
             end
         `endif
-            `INST_LUI: begin 
+            `INST_LUI: begin
                 ex_type = `EX_ALU;
                 op_type = `INST_OP_BITS'(`INST_ALU_LUI);
                 use_rd  = 1;
@@ -229,7 +229,7 @@ module VX_decode  #(
                 imm     = {{`XLEN-31{ui_imm[19]}}, ui_imm[18:0], 12'(0)};
                 `USED_IREG (rd);
             end
-            `INST_AUIPC: begin 
+            `INST_AUIPC: begin
                 ex_type = `EX_ALU;
                 op_type = `INST_OP_BITS'(`INST_ALU_AUIPC);
                 use_rd  = 1;
@@ -238,7 +238,7 @@ module VX_decode  #(
                 imm     = {{`XLEN-31{ui_imm[19]}}, ui_imm[18:0], 12'(0)};
                 `USED_IREG (rd);
             end
-            `INST_JAL: begin 
+            `INST_JAL: begin
                 ex_type = `EX_ALU;
                 op_type = `INST_OP_BITS'(`INST_BR_JAL);
                 op_mod[0] = 1;
@@ -249,7 +249,7 @@ module VX_decode  #(
                 imm     = {{(`XLEN-21){jal_imm[20]}}, jal_imm};
                 `USED_IREG (rd);
             end
-            `INST_JALR: begin 
+            `INST_JALR: begin
                 ex_type = `EX_ALU;
                 op_type = `INST_OP_BITS'(`INST_BR_JALR);
                 op_mod[0] = 1;
@@ -260,7 +260,7 @@ module VX_decode  #(
                 `USED_IREG (rd);
                 `USED_IREG (rs1);
             end
-            `INST_B: begin 
+            `INST_B: begin
                 ex_type = `EX_ALU;
                 op_type = `INST_OP_BITS'(b_type);
                 op_mod[0] = 1;
@@ -275,8 +275,8 @@ module VX_decode  #(
                 ex_type = `EX_LSU;
                 op_type = `INST_LSU_FENCE;
             end
-            `INST_SYS : begin 
-                if (func3[1:0] != 0) begin                    
+            `INST_SYS : begin
+                if (func3[1:0] != 0) begin
                     ex_type = `EX_SFU;
                     op_type = `INST_OP_BITS'(`INST_SFU_CSR(func3[1:0]));
                     use_rd  = 1;
@@ -288,7 +288,7 @@ module VX_decode  #(
                         imm[`VX_CSR_ADDR_BITS +: `NRI_BITS] = rs1; // imm
                     end else begin
                         `USED_IREG (rs1);
-                    end                    
+                    end
                 end else begin
                     ex_type = `EX_ALU;
                     op_type = `INST_OP_BITS'(s_type);
@@ -302,9 +302,9 @@ module VX_decode  #(
                 end
             end
         `ifdef EXT_F_ENABLE
-            `INST_FL, 
+            `INST_FL,
         `endif
-            `INST_L: begin 
+            `INST_L: begin
                 ex_type = `EX_LSU;
                 op_type = `INST_OP_BITS'({1'b0, func3});
                 use_rd  = 1;
@@ -319,9 +319,9 @@ module VX_decode  #(
                 `USED_IREG (rs1);
             end
         `ifdef EXT_F_ENABLE
-            `INST_FS, 
+            `INST_FS,
         `endif
-            `INST_S: begin 
+            `INST_S: begin
                 ex_type = `EX_LSU;
                 op_type = `INST_OP_BITS'({1'b1, func3});
                 imm     = {{(`XLEN-12){s_imm[11]}}, s_imm};
@@ -338,24 +338,24 @@ module VX_decode  #(
             `INST_FMADD,
             `INST_FMSUB,
             `INST_FNMSUB,
-            `INST_FNMADD: begin 
+            `INST_FNMADD: begin
                 ex_type = `EX_FPU;
                 op_type = `INST_OP_BITS'({2'b11, opcode[3:2]});
                 op_mod  = `INST_MOD_BITS'(func3);
                 imm[0]  = func2[0]; // destination is double?
                 use_rd  = 1;
-                `USED_FREG (rd);              
+                `USED_FREG (rd);
                 `USED_FREG (rs1);
                 `USED_FREG (rs2);
                 `USED_FREG (rs3);
             end
-            `INST_FCI: begin 
+            `INST_FCI: begin
                 ex_type = `EX_FPU;
                 op_mod  = `INST_MOD_BITS'(func3);
             `ifdef FLEN_64
                 imm[0]  = func2[0]; // destination is double?
             `endif
-                use_rd  = 1;                
+                use_rd  = 1;
                 case (func5)
                     5'b00000, // FADD
                     5'b00001, // FSUB
@@ -381,28 +381,28 @@ module VX_decode  #(
                         `USED_FREG (rd);
                         `USED_FREG (rs1);
                         `USED_FREG (rs2);
-                    end 
+                    end
                 `ifdef FLEN_64
-                    5'b01000: begin   
+                    5'b01000: begin
                         // CVT.S.D, CVT.D.S
                         op_type = `INST_OP_BITS'(`INST_FPU_F2F);
                         `USED_FREG (rd);
                         `USED_FREG (rs1);
                     end
                 `endif
-                    5'b01011: begin                        
+                    5'b01011: begin
                         // SQRT
                         op_type = `INST_OP_BITS'(`INST_FPU_SQRT);
                         `USED_FREG (rd);
                         `USED_FREG (rs1);
-                    end   
+                    end
                     5'b10100: begin
                         // CMP
                         op_type = `INST_OP_BITS'(`INST_FPU_CMP);
                         `USED_IREG (rd);
                         `USED_FREG (rs1);
                         `USED_FREG (rs2);
-                    end             
+                    end
                     5'b11000: begin
                         // CVT.W.X, CVT.WU.X
                         op_type = (rs2[0]) ? `INST_OP_BITS'(`INST_FPU_F2U) : `INST_OP_BITS'(`INST_FPU_F2I);
@@ -421,10 +421,10 @@ module VX_decode  #(
                         `USED_FREG (rd);
                         `USED_IREG (rs1);
                     end
-                    5'b11100: begin 
+                    5'b11100: begin
                         if (func3[0]) begin
                             // NCP: FCLASS=3
-                            op_type = `INST_OP_BITS'(`INST_FPU_MISC);                                     
+                            op_type = `INST_OP_BITS'(`INST_FPU_MISC);
                             op_mod  = 3;
                         end else begin
                             // NCP: FMV.X.W=4
@@ -432,11 +432,11 @@ module VX_decode  #(
                             op_mod  = 4;
                         end
                         `USED_IREG (rd);
-                        `USED_FREG (rs1);                                           
-                    end 
-                    5'b11110: begin 
+                        `USED_FREG (rs1);
+                    end
+                    5'b11110: begin
                         // NCP: FMV.W.X=5
-                        op_type = `INST_OP_BITS'(`INST_FPU_MISC); 
+                        op_type = `INST_OP_BITS'(`INST_FPU_MISC);
                         op_mod  = 5;
                         `USED_FREG (rd);
                         `USED_IREG (rs1);
@@ -445,7 +445,7 @@ module VX_decode  #(
                 endcase
             end
         `endif
-            `INST_EXT1: begin 
+            `INST_EXT1: begin
                 case (func7)
                     7'h00: begin
                         ex_type = `EX_SFU;
@@ -463,8 +463,8 @@ module VX_decode  #(
                             3'h2: begin // SPLIT
                                 op_type = `INST_OP_BITS'(`INST_SFU_SPLIT);
                                 use_rd    = 1;
-                                `USED_IREG (rs1);                                
-                                `USED_IREG (rd);                                
+                                `USED_IREG (rs1);
+                                `USED_IREG (rd);
                             end
                             3'h3: begin // JOIN
                                 op_type = `INST_OP_BITS'(`INST_SFU_JOIN);
@@ -486,10 +486,10 @@ module VX_decode  #(
                     default:;
                 endcase
             end
-            `INST_EXT2: begin                
+            `INST_EXT2: begin
                 case (func3)
                     3'h1: begin
-                        case (func2)                       
+                        case (func2)
                             2'h0: begin // CMOV
                                 ex_type = `EX_SFU;
                                 op_type = `INST_OP_BITS'(`INST_SFU_CMOV);
@@ -503,6 +503,20 @@ module VX_decode  #(
                         endcase
                     end
                     default:;
+                endcase
+            end
+            `INST_EXT3: begin // Mod3
+                case (func3)
+                    3'h0: begin
+                    op_type = `INST_OP_BITS'(`INST_MLOAD);
+                    ex_type = `EX_LSU;
+                    // Input addresses
+                    `USED_IREG (rs1);
+                    `USED_IREG (rs2);
+                    // Output register
+                    use_rd  = 1;
+                    `USED_IREG (rd);
+                    end
                 endcase
             end
             default:;
@@ -533,7 +547,7 @@ module VX_decode  #(
     assign decode_sched_if.valid    = fetch_fire;
     assign decode_sched_if.wid      = fetch_if.data.wid;
     assign decode_sched_if.is_wstall = is_wstall;
-`ifndef L1_ENABLE    
+`ifndef L1_ENABLE
     assign fetch_if.ibuf_pop = decode_if.ibuf_pop;
 `endif
 

--- a/hw/rtl/core/VX_decode.sv
+++ b/hw/rtl/core/VX_decode.sv
@@ -514,7 +514,7 @@ module VX_decode  #(
                     `USED_IREG (rs1);
                     `USED_IREG (rs2);
                     // Output register
-                    use_rd  = 1;
+                    // use_rd  = 1; TODO: is this needed? hint: probably not
                     `USED_IREG (rd);
                     end
                 endcase

--- a/hw/rtl/core/VX_dispatch.sv
+++ b/hw/rtl/core/VX_dispatch.sv
@@ -209,7 +209,6 @@ module VX_dispatch import VX_gpu_pkg::*; #(
             end
         end
     end
-    
     for (genvar i=0; i < `NUM_EX_UNITS; ++i) begin
         assign perf_stalls[i] = perf_stalls_r[i];
     end

--- a/hw/rtl/core/VX_dispatch_unit.sv
+++ b/hw/rtl/core/VX_dispatch_unit.sv
@@ -227,14 +227,14 @@ module VX_dispatch_unit import VX_gpu_pkg::*; #(
             .reset     (buf_out_reset),
             .valid_in  (valid_p),
             .ready_in  (ready_p),
-            .data_in   ({                
+            .data_in   ({
                 dispatch_data[issue_idx][IN_DATAW-1 : DATA_TMASK_OFF+`NUM_THREADS+ISSUE_WIS_W],
                 block_wid,
                 block_tmask[block_idx],
                 dispatch_data[issue_idx][DATA_TMASK_OFF-1 : DATA_REGS_OFF + 3 * `NUM_THREADS * `XLEN],
                 block_regs[block_idx][0],
                 block_regs[block_idx][1],
-                block_regs[block_idx][2],     
+                block_regs[block_idx][2],
                 block_pid[block_idx],
                 block_sop[block_idx],
                 block_eop[block_idx]}),

--- a/hw/rtl/core/VX_execute.sv
+++ b/hw/rtl/core/VX_execute.sv
@@ -124,19 +124,6 @@ module VX_execute import VX_gpu_pkg::*; #(
         .commit_if      (sfu_commit_if)
     );
 
-    for (genvar i = 0; i < `ISSUE_WIDTH; ++i) begin
-        assign alu_commit_if[i].data.microop_id = '0;
-        assign alu_commit_if[i].data.is_microop = '0;
-
-        `ifdef EXT_F_ENABLE
-        assign fpu_commit_if[i].data.microop_id = '0;
-        assign fpu_commit_if[i].data.is_microop = '0;
-        `endif
-
-        assign sfu_commit_if[i].data.microop_id = '0;
-        assign sfu_commit_if[i].data.is_microop = '0;
-    end
-
     // simulation helper signal to get RISC-V tests Pass/Fail status
     assign sim_ebreak = alu_dispatch_if[0].valid && alu_dispatch_if[0].ready
                      && alu_dispatch_if[0].data.wis == 0

--- a/hw/rtl/core/VX_fpu_unit.sv
+++ b/hw/rtl/core/VX_fpu_unit.sv
@@ -62,7 +62,7 @@ module VX_fpu_unit import VX_fpu_pkg::*; #(
 
         // Store request info
         wire fpu_req_valid, fpu_req_ready;
-        wire fpu_rsp_valid, fpu_rsp_ready;    
+        wire fpu_rsp_valid, fpu_rsp_ready;
         wire [NUM_LANES-1:0][`XLEN-1:0] fpu_rsp_result;
         fflags_t fpu_rsp_fflags;
         wire fpu_rsp_has_fflags;
@@ -76,7 +76,7 @@ module VX_fpu_unit import VX_fpu_pkg::*; #(
         wire                    fpu_rsp_sop;
         wire                    fpu_rsp_eop;
 
-        wire [TAG_WIDTH-1:0] fpu_req_tag, fpu_rsp_tag;    
+        wire [TAG_WIDTH-1:0] fpu_req_tag, fpu_rsp_tag;
         wire mdata_full;
 
         wire [`INST_FMT_BITS-1:0] fpu_fmt = execute_if[block_idx].data.imm[`INST_FMT_BITS-1:0];
@@ -91,20 +91,20 @@ module VX_fpu_unit import VX_fpu_pkg::*; #(
         ) tag_store (
             .clk          (clk),
             .reset        (reset),
-            .acquire_en   (execute_fire), 
-            .write_addr   (fpu_req_tag), 
+            .acquire_en   (execute_fire),
+            .write_addr   (fpu_req_tag),
             .write_data   ({execute_if[block_idx].data.uuid, execute_if[block_idx].data.wid, execute_if[block_idx].data.tmask, execute_if[block_idx].data.PC, execute_if[block_idx].data.rd, execute_if[block_idx].data.pid, execute_if[block_idx].data.sop, execute_if[block_idx].data.eop}),
             .read_data    ({fpu_rsp_uuid, fpu_rsp_wid, fpu_rsp_tmask, fpu_rsp_PC, fpu_rsp_rd, fpu_rsp_pid, fpu_rsp_sop, fpu_rsp_eop}),
             .read_addr    (fpu_rsp_tag),
-            .release_en   (fpu_rsp_fire), 
+            .release_en   (fpu_rsp_fire),
             .full         (mdata_full),
             `UNUSED_PIN (empty)
         );
 
-        // resolve dynamic FRM from CSR   
-        wire [`INST_FRM_BITS-1:0] fpu_req_frm; 
+        // resolve dynamic FRM from CSR
+        wire [`INST_FRM_BITS-1:0] fpu_req_frm;
         `ASSIGN_BLOCKED_WID (fpu_to_csr_if[block_idx].read_wid, execute_if[block_idx].data.wid, block_idx, `NUM_FPU_BLOCKS)
-        assign fpu_req_frm = (execute_if[block_idx].data.op_type != `INST_FPU_MISC 
+        assign fpu_req_frm = (execute_if[block_idx].data.op_type != `INST_FPU_MISC
                            && fpu_frm == `INST_FRM_DYN) ? fpu_to_csr_if[block_idx].read_frm : fpu_frm;
 
         // submit FPU request
@@ -112,7 +112,7 @@ module VX_fpu_unit import VX_fpu_pkg::*; #(
         assign fpu_req_valid = execute_if[block_idx].valid && ~mdata_full;
         assign execute_if[block_idx].ready = fpu_req_ready && ~mdata_full;
 
-        `RESET_RELAY (fpu_reset, reset);   
+        `RESET_RELAY (fpu_reset, reset);
 
     `ifdef FPU_DPI
 
@@ -140,8 +140,8 @@ module VX_fpu_unit import VX_fpu_pkg::*; #(
             .has_fflags (fpu_rsp_has_fflags),
             .fflags     (fpu_rsp_fflags),
             .tag_out    (fpu_rsp_tag),
-            .ready_out  (fpu_rsp_ready)     
-        );   
+            .ready_out  (fpu_rsp_ready)
+        );
 
     `elsif FPU_FPNEW
 
@@ -151,7 +151,7 @@ module VX_fpu_unit import VX_fpu_pkg::*; #(
             .OUT_REG    (PARTIAL_BW ? 1 : 3)
         ) fpu_fpnew (
             .clk        (clk),
-            .reset      (fpu_reset), 
+            .reset      (fpu_reset),
 
             .valid_in   (fpu_req_valid),
             .op_type    (execute_if[block_idx].data.op_type),
@@ -160,16 +160,16 @@ module VX_fpu_unit import VX_fpu_pkg::*; #(
             .frm        (fpu_req_frm),
             .dataa      (execute_if[block_idx].data.rs1_data),
             .datab      (execute_if[block_idx].data.rs2_data),
-            .datac      (execute_if[block_idx].data.rs3_data), 
+            .datac      (execute_if[block_idx].data.rs3_data),
             .tag_in     (fpu_req_tag),
             .ready_in   (fpu_req_ready),
 
-            .valid_out  (fpu_rsp_valid), 
+            .valid_out  (fpu_rsp_valid),
             .result     (fpu_rsp_result),
             .has_fflags (fpu_rsp_has_fflags),
             .fflags     (fpu_rsp_fflags),
-            .tag_out    (fpu_rsp_tag), 
-            .ready_out  (fpu_rsp_ready)        
+            .tag_out    (fpu_rsp_tag),
+            .ready_out  (fpu_rsp_ready)
         );
 
     `elsif FPU_DSP
@@ -180,7 +180,7 @@ module VX_fpu_unit import VX_fpu_pkg::*; #(
             .OUT_REG    (PARTIAL_BW ? 1 : 3)
         ) fpu_dsp (
             .clk        (clk),
-            .reset      (fpu_reset), 
+            .reset      (fpu_reset),
 
             .valid_in   (fpu_req_valid),
             .lane_mask  (execute_if[block_idx].data.tmask),
@@ -189,18 +189,17 @@ module VX_fpu_unit import VX_fpu_pkg::*; #(
             .frm        (fpu_req_frm),
             .dataa      (execute_if[block_idx].data.rs1_data),
             .datab      (execute_if[block_idx].data.rs2_data),
-            .datac      (execute_if[block_idx].data.rs3_data), 
+            .datac      (execute_if[block_idx].data.rs3_data),
             .tag_in     (fpu_req_tag),
             .ready_in   (fpu_req_ready),
 
-            .valid_out  (fpu_rsp_valid), 
-            .result     (fpu_rsp_result), 
+            .valid_out  (fpu_rsp_valid),
+            .result     (fpu_rsp_result),
             .has_fflags (fpu_rsp_has_fflags),
             .fflags     (fpu_rsp_fflags),
             .tag_out    (fpu_rsp_tag),
             .ready_out  (fpu_rsp_ready)
         );
-        
     `endif
 
         // handle FPU response
@@ -220,23 +219,25 @@ module VX_fpu_unit import VX_fpu_pkg::*; #(
         end else begin
             assign fpu_rsp_fflags_q = fpu_rsp_fflags;
         end
-        
         assign fpu_to_csr_if[block_idx].write_enable = fpu_rsp_fire && fpu_rsp_eop && fpu_rsp_has_fflags;
         `ASSIGN_BLOCKED_WID (fpu_to_csr_if[block_idx].write_wid, fpu_rsp_wid, block_idx, `NUM_FPU_BLOCKS)
         assign fpu_to_csr_if[block_idx].write_fflags = fpu_rsp_fflags_q;
 
         // send response
 
+        wire [`NT_BITS:0] microop_id;
+        assign microop_id = '0;
+
         VX_elastic_buffer #(
-            .DATAW (`UUID_WIDTH + `NW_WIDTH + NUM_LANES + `XLEN + `NR_BITS + (NUM_LANES * `XLEN) + PID_WIDTH + 1 + 1),
+            .DATAW (`UUID_WIDTH + `NW_WIDTH + NUM_LANES + `XLEN + `NR_BITS + (NUM_LANES * `XLEN) + PID_WIDTH + 1 + 1 + `NT_BITS + 1 + 1),
             .SIZE  (0)
         ) rsp_buf (
             .clk       (clk),
             .reset     (reset),
             .valid_in  (fpu_rsp_valid),
             .ready_in  (fpu_rsp_ready),
-            .data_in   ({fpu_rsp_uuid, fpu_rsp_wid, fpu_rsp_tmask, fpu_rsp_PC, fpu_rsp_rd, fpu_rsp_result, fpu_rsp_pid, fpu_rsp_sop, fpu_rsp_eop}),
-            .data_out  ({commit_block_if[block_idx].data.uuid, commit_block_if[block_idx].data.wid, commit_block_if[block_idx].data.tmask, commit_block_if[block_idx].data.PC, commit_block_if[block_idx].data.rd, commit_block_if[block_idx].data.data, commit_block_if[block_idx].data.pid, commit_block_if[block_idx].data.sop, commit_block_if[block_idx].data.eop}),
+            .data_in   ({fpu_rsp_uuid, fpu_rsp_wid, fpu_rsp_tmask, fpu_rsp_PC, fpu_rsp_rd, fpu_rsp_result, fpu_rsp_pid, fpu_rsp_sop, fpu_rsp_eop, microop_id, 1'b0}),
+            .data_out  ({commit_block_if[block_idx].data.uuid, commit_block_if[block_idx].data.wid, commit_block_if[block_idx].data.tmask, commit_block_if[block_idx].data.PC, commit_block_if[block_idx].data.rd, commit_block_if[block_idx].data.data, commit_block_if[block_idx].data.pid, commit_block_if[block_idx].data.sop, commit_block_if[block_idx].data.eop, commit_block_if[block_idx].data.microop_id, commit_block_if[block_idx].data.is_microop}),
             .valid_out (commit_block_if[block_idx].valid),
             .ready_out (commit_block_if[block_idx].ready)
         );

--- a/hw/rtl/core/VX_fpu_unit.sv
+++ b/hw/rtl/core/VX_fpu_unit.sv
@@ -226,15 +226,15 @@ module VX_fpu_unit import VX_fpu_pkg::*; #(
         // send response
 
         VX_elastic_buffer #(
-            .DATAW (`UUID_WIDTH + `NW_WIDTH + NUM_LANES + `XLEN + `NR_BITS + (NUM_LANES * `XLEN) + PID_WIDTH + 1 + 1),
+            .DATAW (`UUID_WIDTH + `NW_WIDTH + NUM_LANES + `XLEN + `NR_BITS + (NUM_LANES * `XLEN) + PID_WIDTH + 1 + 1 + 1),
             .SIZE  (0)
         ) rsp_buf (
             .clk       (clk),
             .reset     (reset),
             .valid_in  (fpu_rsp_valid),
             .ready_in  (fpu_rsp_ready),
-            .data_in   ({fpu_rsp_uuid, fpu_rsp_wid, fpu_rsp_tmask, fpu_rsp_PC, fpu_rsp_rd, fpu_rsp_result, fpu_rsp_pid, fpu_rsp_sop, fpu_rsp_eop}),
-            .data_out  ({commit_block_if[block_idx].data.uuid, commit_block_if[block_idx].data.wid, commit_block_if[block_idx].data.tmask, commit_block_if[block_idx].data.PC, commit_block_if[block_idx].data.rd, commit_block_if[block_idx].data.data, commit_block_if[block_idx].data.pid, commit_block_if[block_idx].data.sop, commit_block_if[block_idx].data.eop }),
+            .data_in   ({fpu_rsp_uuid, fpu_rsp_wid, fpu_rsp_tmask, fpu_rsp_PC, fpu_rsp_rd, fpu_rsp_result, fpu_rsp_pid, fpu_rsp_sop, fpu_rsp_eop, 1'b1}),
+            .data_out  ({commit_block_if[block_idx].data.uuid, commit_block_if[block_idx].data.wid, commit_block_if[block_idx].data.tmask, commit_block_if[block_idx].data.PC, commit_block_if[block_idx].data.rd, commit_block_if[block_idx].data.data, commit_block_if[block_idx].data.pid, commit_block_if[block_idx].data.sop, commit_block_if[block_idx].data.eop, commit_block_if[block_idx].data.true_eop}),
             .valid_out (commit_block_if[block_idx].valid),
             .ready_out (commit_block_if[block_idx].ready)
         );

--- a/hw/rtl/core/VX_fpu_unit.sv
+++ b/hw/rtl/core/VX_fpu_unit.sv
@@ -225,19 +225,16 @@ module VX_fpu_unit import VX_fpu_pkg::*; #(
 
         // send response
 
-        wire [`NT_BITS:0] microop_id;
-        assign microop_id = '0;
-
         VX_elastic_buffer #(
-            .DATAW (`UUID_WIDTH + `NW_WIDTH + NUM_LANES + `XLEN + `NR_BITS + (NUM_LANES * `XLEN) + PID_WIDTH + 1 + 1 + `NT_BITS + 1 + 1),
+            .DATAW (`UUID_WIDTH + `NW_WIDTH + NUM_LANES + `XLEN + `NR_BITS + (NUM_LANES * `XLEN) + PID_WIDTH + 1 + 1),
             .SIZE  (0)
         ) rsp_buf (
             .clk       (clk),
             .reset     (reset),
             .valid_in  (fpu_rsp_valid),
             .ready_in  (fpu_rsp_ready),
-            .data_in   ({fpu_rsp_uuid, fpu_rsp_wid, fpu_rsp_tmask, fpu_rsp_PC, fpu_rsp_rd, fpu_rsp_result, fpu_rsp_pid, fpu_rsp_sop, fpu_rsp_eop, microop_id, 1'b0}),
-            .data_out  ({commit_block_if[block_idx].data.uuid, commit_block_if[block_idx].data.wid, commit_block_if[block_idx].data.tmask, commit_block_if[block_idx].data.PC, commit_block_if[block_idx].data.rd, commit_block_if[block_idx].data.data, commit_block_if[block_idx].data.pid, commit_block_if[block_idx].data.sop, commit_block_if[block_idx].data.eop, commit_block_if[block_idx].data.microop_id, commit_block_if[block_idx].data.is_microop}),
+            .data_in   ({fpu_rsp_uuid, fpu_rsp_wid, fpu_rsp_tmask, fpu_rsp_PC, fpu_rsp_rd, fpu_rsp_result, fpu_rsp_pid, fpu_rsp_sop, fpu_rsp_eop}),
+            .data_out  ({commit_block_if[block_idx].data.uuid, commit_block_if[block_idx].data.wid, commit_block_if[block_idx].data.tmask, commit_block_if[block_idx].data.PC, commit_block_if[block_idx].data.rd, commit_block_if[block_idx].data.data, commit_block_if[block_idx].data.pid, commit_block_if[block_idx].data.sop, commit_block_if[block_idx].data.eop }),
             .valid_out (commit_block_if[block_idx].valid),
             .ready_out (commit_block_if[block_idx].ready)
         );

--- a/hw/rtl/core/VX_gather_unit.sv
+++ b/hw/rtl/core/VX_gather_unit.sv
@@ -31,7 +31,7 @@ module VX_gather_unit import VX_gpu_pkg::*; #(
     localparam BLOCK_SIZE_W = `LOG2UP(BLOCK_SIZE);
     localparam PID_BITS     = `CLOG2(`NUM_THREADS / NUM_LANES);
     localparam PID_WIDTH    = `UP(PID_BITS);
-    localparam DATAW        = `UUID_WIDTH + `NW_WIDTH + NUM_LANES + `XLEN + 1 + `NR_BITS + NUM_LANES * `XLEN + PID_WIDTH + 1 + 1;
+    localparam DATAW        = `UUID_WIDTH + `NW_WIDTH + NUM_LANES + `XLEN + 1 + `NR_BITS + NUM_LANES * `XLEN + PID_WIDTH + 1 + 1 + 1;
     localparam DATA_WIS_OFF = DATAW - (`UUID_WIDTH + `NW_WIDTH);
 
     wire [BLOCK_SIZE-1:0] commit_in_valid;
@@ -121,7 +121,8 @@ module VX_gather_unit import VX_gpu_pkg::*; #(
             commit_data_r,
             1'b0, // PID
             commit_tmp_if.data.sop,
-            commit_tmp_if.data.eop
+            commit_tmp_if.data.eop,
+            commit_tmp_if.data.true_eop
         };
         assign commit_tmp_if.ready = commit_out_if[i].ready;
     end

--- a/hw/rtl/core/VX_gather_unit.sv
+++ b/hw/rtl/core/VX_gather_unit.sv
@@ -31,7 +31,7 @@ module VX_gather_unit import VX_gpu_pkg::*; #(
     localparam BLOCK_SIZE_W = `LOG2UP(BLOCK_SIZE);
     localparam PID_BITS     = `CLOG2(`NUM_THREADS / NUM_LANES);
     localparam PID_WIDTH    = `UP(PID_BITS);
-    localparam DATAW        = `UUID_WIDTH + `NW_WIDTH + NUM_LANES + `XLEN + 1 + `NR_BITS + NUM_LANES * `XLEN + PID_WIDTH + 1 + 1;
+    localparam DATAW        = `UUID_WIDTH + `NW_WIDTH + NUM_LANES + `XLEN + 1 + `NR_BITS + NUM_LANES * `XLEN + PID_WIDTH + 1 + 1 + `NT_BITS + 1 + 1;
     localparam DATA_WIS_OFF = DATAW - (`UUID_WIDTH + `NW_WIDTH);
 
     wire [BLOCK_SIZE-1:0] commit_in_valid;
@@ -88,7 +88,7 @@ module VX_gather_unit import VX_gpu_pkg::*; #(
             .reset      (commit_out_reset),
             .valid_in   (commit_out_valid[i]),
             .ready_in   (commit_out_ready[i]),
-            .data_in    (commit_out_data[i]),            
+            .data_in    (commit_out_data[i]),
             .data_out   (commit_tmp_if.data),
             .valid_out  (commit_tmp_if.valid),
             .ready_out  (commit_tmp_if.ready)
@@ -121,7 +121,9 @@ module VX_gather_unit import VX_gpu_pkg::*; #(
             commit_data_r,
             1'b0, // PID
             commit_tmp_if.data.sop,
-            commit_tmp_if.data.eop
+            commit_tmp_if.data.eop,
+            commit_tmp_if.data.microop_id,
+            commit_tmp_if.data.is_microop
         };
         assign commit_tmp_if.ready = commit_out_if[i].ready;
     end

--- a/hw/rtl/core/VX_gather_unit.sv
+++ b/hw/rtl/core/VX_gather_unit.sv
@@ -31,7 +31,7 @@ module VX_gather_unit import VX_gpu_pkg::*; #(
     localparam BLOCK_SIZE_W = `LOG2UP(BLOCK_SIZE);
     localparam PID_BITS     = `CLOG2(`NUM_THREADS / NUM_LANES);
     localparam PID_WIDTH    = `UP(PID_BITS);
-    localparam DATAW        = `UUID_WIDTH + `NW_WIDTH + NUM_LANES + `XLEN + 1 + `NR_BITS + NUM_LANES * `XLEN + PID_WIDTH + 1 + 1 + `NT_BITS + 1 + 1;
+    localparam DATAW        = `UUID_WIDTH + `NW_WIDTH + NUM_LANES + `XLEN + 1 + `NR_BITS + NUM_LANES * `XLEN + PID_WIDTH + 1 + 1;
     localparam DATA_WIS_OFF = DATAW - (`UUID_WIDTH + `NW_WIDTH);
 
     wire [BLOCK_SIZE-1:0] commit_in_valid;
@@ -121,9 +121,7 @@ module VX_gather_unit import VX_gpu_pkg::*; #(
             commit_data_r,
             1'b0, // PID
             commit_tmp_if.data.sop,
-            commit_tmp_if.data.eop,
-            commit_tmp_if.data.microop_id,
-            commit_tmp_if.data.is_microop
+            commit_tmp_if.data.eop
         };
         assign commit_tmp_if.ready = commit_out_if[i].ready;
     end

--- a/hw/rtl/core/VX_ibuffer.sv
+++ b/hw/rtl/core/VX_ibuffer.sv
@@ -28,12 +28,10 @@ module VX_ibuffer import VX_gpu_pkg::*; #(
     `UNUSED_PARAM (CORE_ID)
     localparam ISW_WIDTH  = `LOG2UP(`ISSUE_WIDTH);
     localparam DATAW = `UUID_WIDTH + ISSUE_WIS_W + `NUM_THREADS + `XLEN + 1 + `EX_BITS + `INST_OP_BITS + `INST_MOD_BITS + 1 + 1 + `XLEN + (`NR_BITS * 4);
-    
     wire [`ISSUE_WIDTH-1:0] ibuf_ready_in;
 
     wire [ISW_WIDTH-1:0] decode_isw = wid_to_isw(decode_if.data.wid);
     wire [ISSUE_WIS_W-1:0] decode_wis = wid_to_wis(decode_if.data.wid);
-    
     assign decode_if.ready = ibuf_ready_in[decode_isw];
 
     for (genvar i = 0; i < `ISSUE_WIDTH; ++i) begin

--- a/hw/rtl/core/VX_int_unit.sv
+++ b/hw/rtl/core/VX_int_unit.sv
@@ -136,14 +136,14 @@ module VX_int_unit #(
     end   
 
     VX_elastic_buffer #(
-        .DATAW (`UUID_WIDTH + `NW_WIDTH + NUM_LANES + `NR_BITS + 1 + PID_WIDTH + 1 + 1 + (NUM_LANES * `XLEN) + `XLEN + `XLEN + 1 + `INST_BR_BITS + LANE_WIDTH)
+        .DATAW (`UUID_WIDTH + `NW_WIDTH + NUM_LANES + `NR_BITS + 1 + PID_WIDTH + 1 + 1 + (NUM_LANES * `XLEN) + `XLEN + `XLEN + 1 + `INST_BR_BITS + LANE_WIDTH + 1)
     ) rsp_buf (
         .clk      (clk),
         .reset    (reset),
         .valid_in (execute_if.valid),
         .ready_in (execute_if.ready),
-        .data_in  ({execute_if.data.uuid, execute_if.data.wid, execute_if.data.tmask, execute_if.data.rd, execute_if.data.wb, execute_if.data.pid, execute_if.data.sop, execute_if.data.eop, alu_result, execute_if.data.PC, execute_if.data.imm, is_br_op, br_op, tid}),
-        .data_out ({commit_if.data.uuid, commit_if.data.wid, commit_if.data.tmask, commit_if.data.rd, commit_if.data.wb, commit_if.data.pid, commit_if.data.sop, commit_if.data.eop, alu_result_r, PC_r, imm_r, is_br_op_r, br_op_r, tid_r}),
+        .data_in  ({execute_if.data.uuid, execute_if.data.wid, execute_if.data.tmask, execute_if.data.rd, execute_if.data.wb, execute_if.data.pid, execute_if.data.sop, execute_if.data.eop, alu_result, execute_if.data.PC, execute_if.data.imm, is_br_op, br_op, tid , 1'b1}),
+        .data_out ({commit_if.data.uuid, commit_if.data.wid, commit_if.data.tmask, commit_if.data.rd, commit_if.data.wb, commit_if.data.pid, commit_if.data.sop, commit_if.data.eop, alu_result_r, PC_r, imm_r, is_br_op_r, br_op_r, tid_r, commit_if.data.true_eop}),
         .valid_out (commit_if.valid),
         .ready_out (commit_if.ready)
     );

--- a/hw/rtl/core/VX_issue.sv
+++ b/hw/rtl/core/VX_issue.sv
@@ -1,10 +1,10 @@
 // Copyright © 2019-2023
-// 
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 // http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -49,7 +49,7 @@ module VX_issue #(
         .CORE_ID (CORE_ID)
     ) ibuffer (
         .clk            (clk),
-        .reset          (ibuf_reset), 
+        .reset          (ibuf_reset),
         .decode_if      (decode_if),
         .ibuffer_if     (ibuffer_if)
     );
@@ -72,8 +72,8 @@ module VX_issue #(
     VX_operands #(
         .CORE_ID (CORE_ID)
     ) operands (
-        .clk            (clk), 
-        .reset          (operands_reset), 
+        .clk            (clk),
+        .reset          (operands_reset),
         .writeback_if   (writeback_if),
         .scoreboard_if  (scoreboard_if),
         .operands_if    (operands_if)
@@ -82,7 +82,7 @@ module VX_issue #(
     VX_dispatch #(
         .CORE_ID (CORE_ID)
     ) dispatch (
-        .clk            (clk), 
+        .clk            (clk),
         .reset          (dispatch_reset),
     `ifdef PERF_ENABLE
         `UNUSED_PIN     (perf_stalls),
@@ -94,7 +94,7 @@ module VX_issue #(
         .fpu_dispatch_if(fpu_dispatch_if),
     `endif
         .sfu_dispatch_if(sfu_dispatch_if)
-    ); 
+    );
 
 `ifdef DBG_SCOPE_ISSUE
     if (CORE_ID == 0) begin
@@ -114,9 +114,9 @@ module VX_issue #(
             .start(1'b0),
             .stop(1'b0),
             .triggers({
-                reset, 
+                reset,
                 operands_if_fire,
-                operands_if_not_ready, 
+                operands_if_not_ready,
                 writeback_if_valid
             }),
             .probes({
@@ -142,7 +142,7 @@ module VX_issue #(
             .bus_in(scope_bus_in),
             .bus_out(scope_bus_out)
         );
-    `endif        
+    `endif
     `ifdef CHIPSCOPE
         ila_issue ila_issue_inst (
             .clk    (clk),
@@ -157,7 +157,6 @@ module VX_issue #(
 
 `ifdef PERF_ENABLE
     reg [`PERF_CTR_BITS-1:0] perf_ibf_stalls;
-    
     wire decode_stall = decode_if.valid && ~decode_if.ready;
 
     always @(posedge clk) begin

--- a/hw/rtl/core/VX_lsu_unit.sv
+++ b/hw/rtl/core/VX_lsu_unit.sv
@@ -614,7 +614,10 @@ module VX_lsu_unit import VX_gpu_pkg::*; #(
             LSU_NORMAL: begin
                 mload_count_n = '0;
                 if (is_mload) begin
-                    state_n = LSU_MLOAD;
+                    if (lsu_ready) begin
+                        state_n = LSU_MLOAD;
+                        mload_count_n = mload_count_q + 1'b1;
+                    end
                 end
             end
             LSU_MLOAD: begin

--- a/hw/rtl/core/VX_lsu_unit.sv
+++ b/hw/rtl/core/VX_lsu_unit.sv
@@ -322,8 +322,17 @@ module VX_lsu_unit import VX_gpu_pkg::*; #(
         `UNUSED_VAR (pkt_raddr)
     end
 
+    // For mload, destination registers are 4 and are contiguous in the register file.
+    wire [`NR_BITS-1:0] mem_req_rd;
+    if (execute_if[0].data.op_type == `INST_MLOAD) begin
+        assign mem_req_rd = execute_if[0].data.rd + `NR_BITS(mload_finished);
+    end else begin
+        assign mem_req_rd = execute_if[0].data.rd;
+    end
+
     assign mem_req_tag = {
-        execute_if[0].data.uuid, lsu_addr_type, execute_if[0].data.wid, execute_if[0].data.tmask, execute_if[0].data.PC, execute_if[0].data.rd, execute_if[0].data.op_type, req_align, execute_if[0].data.pid, pkt_waddr
+        execute_if[0].data.uuid, lsu_addr_type, execute_if[0].data.wid, execute_if[0].data.tmask, execute_if[0].data.PC,
+        mem_req_rd , execute_if[0].data.op_type, req_align, execute_if[0].data.pid, pkt_waddr
     `ifdef LSU_DUP_ENABLE
         , lsu_is_dup
     `endif

--- a/hw/rtl/core/VX_lsu_unit.sv
+++ b/hw/rtl/core/VX_lsu_unit.sv
@@ -1,10 +1,10 @@
 // Copyright © 2019-2023
-// 
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 // http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -15,11 +15,11 @@
 
 module VX_lsu_unit import VX_gpu_pkg::*; #(
     parameter CORE_ID = 0
-) (    
+) (
     `SCOPE_IO_DECL
 
    input wire               clk,
-    input wire              reset,
+   input wire              reset,
 
    // Dcache interface
     VX_mem_bus_if.master    cache_bus_if [DCACHE_NUM_REQS],
@@ -27,7 +27,7 @@ module VX_lsu_unit import VX_gpu_pkg::*; #(
     // inputs
     VX_dispatch_if.slave    dispatch_if [`ISSUE_WIDTH],
 
-    // outputs    
+    // outputs
     VX_commit_if.master     commit_if [`ISSUE_WIDTH]
 );
     localparam BLOCK_SIZE   = 1;
@@ -36,7 +36,7 @@ module VX_lsu_unit import VX_gpu_pkg::*; #(
     localparam PID_WIDTH    = `UP(PID_BITS);
     localparam RSP_ARB_DATAW= `UUID_WIDTH + `NW_WIDTH + NUM_LANES + `XLEN + `NR_BITS + 1 + NUM_LANES * `XLEN + PID_WIDTH + 1 + 1;
     localparam LSUQ_SIZEW   = `LOG2UP(`LSUQ_SIZE);
-    localparam MEM_ASHIFT   = `CLOG2(`MEM_BLOCK_SIZE);    
+    localparam MEM_ASHIFT   = `CLOG2(`MEM_BLOCK_SIZE);
     localparam MEM_ADDRW    = `XLEN - MEM_ASHIFT;
     localparam REQ_ASHIFT   = `CLOG2(DCACHE_WORD_SIZE);
     localparam CACHE_TAG_WIDTH = `UUID_WIDTH + (NUM_LANES * `CACHE_ADDR_TYPE_BITS) + LSUQ_TAG_BITS;
@@ -61,12 +61,12 @@ module VX_lsu_unit import VX_gpu_pkg::*; #(
     VX_commit_if #(
         .NUM_LANES (NUM_LANES)
     ) commit_st_if();
-    
+
     VX_commit_if #(
         .NUM_LANES (NUM_LANES)
     ) commit_ld_if();
-    
-    `UNUSED_VAR (execute_if[0].data.op_mod)     
+
+    `UNUSED_VAR (execute_if[0].data.op_mod)
     `UNUSED_VAR (execute_if[0].data.use_PC)
     `UNUSED_VAR (execute_if[0].data.use_imm)
     `UNUSED_VAR (execute_if[0].data.rs3_data)
@@ -79,25 +79,45 @@ module VX_lsu_unit import VX_gpu_pkg::*; #(
     localparam SMEM_END_B = MEM_ADDRW'((`XLEN'(`SMEM_BASE_ADDR) + (1 << `SMEM_LOG_SIZE)) >> MEM_ASHIFT);
 `endif
 
-    // tag = uuid + addr_type + wid + PC + tmask + rd + op_type + align + is_dup + pid + pkt_addr 
+    // tag = uuid + addr_type + wid + PC + tmask + rd + op_type + align + is_dup + pid + pkt_addr
     localparam TAG_WIDTH = `UUID_WIDTH + (NUM_LANES * `CACHE_ADDR_TYPE_BITS) + `NW_WIDTH + `XLEN + NUM_LANES + `NR_BITS + `INST_LSU_BITS + (NUM_LANES * (REQ_ASHIFT)) + `LSU_DUP_ENABLED + PID_WIDTH + LSUQ_SIZEW;
 
     `STATIC_ASSERT(0 == (`IO_BASE_ADDR % `MEM_BLOCK_SIZE), ("invalid parameter"))
 
     wire [NUM_LANES-1:0][`CACHE_ADDR_TYPE_BITS-1:0] lsu_addr_type;
 
-    // full address calculation
 
-    wire [NUM_LANES-1:0][`XLEN-1:0] full_addr;    
+    reg [2:0] mload_finished;
+    wire addr_offset;
+    // First matrix accesses have offset (tid / 2) * 2
+    assign addr_offset_1 = (execute_if[0].data.tid >> 1) << 1;
+    // Second matrix accesses have offset (tid % 2)
+    assign addr_offset_2 = (execute_if[0].data.tid[0]);
+
+    // Full address calculation
+    // TODO set different address calculation for different op_type (for load)
+    wire [NUM_LANES-1:0][`XLEN-1:0] full_addr;
     for (genvar i = 0; i < NUM_LANES; ++i) begin
-        assign full_addr[i] = execute_if[0].data.rs1_data[i][`XLEN-1:0] + execute_if[0].data.imm;
+        if (execute_if[0].data.op_type == `INST_MLOAD) begin
+            if (mload_finished < 2) begin
+                // First two loads
+                assign full_addr[i] = execute_if[0].data.rs1_data[i][`XLEN-1:0] + addr_offset_1
+                                    + (mload_finished == 3'b1); // Stride is 1 for the second element accessed
+            end else begin
+                // Second two loads
+                assign full_addr[i] = execute_if[0].data.rs2_data[i][`XLEN-1:0] + addr_offset_2
+                                    + (mload_finished == 3'b3) << 1; // Stride is 2 for the second element accessed
+            end
+        end else begin
+            assign full_addr[i] = execute_if[0].data.rs1_data[i][`XLEN-1:0] + execute_if[0].data.imm;
+        end
     end
 
     // detect duplicate addresses
 
     wire lsu_is_dup;
 `ifdef LSU_DUP_ENABLE
-    if (NUM_LANES > 1) begin    
+    if (NUM_LANES > 1) begin
         wire [NUM_LANES-2:0] addr_matches;
         for (genvar i = 0; i < (NUM_LANES-1); ++i) begin
             assign addr_matches[i] = (execute_if[0].data.rs1_data[i+1] == execute_if[0].data.rs1_data[0]) || ~execute_if[0].data.tmask[i+1];
@@ -132,15 +152,16 @@ module VX_lsu_unit import VX_gpu_pkg::*; #(
     // fence: stall the pipeline until all pending requests are sent
     wire is_fence = `INST_LSU_IS_FENCE(execute_if[0].data.op_type);
     wire fence_wait = is_fence && ~mem_req_empty;
-    
+
+    // TODO 1 stall when
     assign lsu_valid = execute_if[0].valid && ~fence_wait;
     assign execute_if[0].ready = lsu_ready && ~fence_wait;
 
-    // schedule memory request    
+    // schedule memory request
 
     wire                            mem_req_valid;
     wire [NUM_LANES-1:0]            mem_req_mask;
-    wire                            mem_req_rw;  
+    wire                            mem_req_rw;
     wire [NUM_LANES-1:0][`MEM_ADDR_WIDTH-REQ_ASHIFT-1:0] mem_req_addr;
     reg  [NUM_LANES-1:0][DCACHE_WORD_SIZE-1:0] mem_req_byteen;
     reg  [NUM_LANES-1:0][`XLEN-1:0] mem_req_data;
@@ -156,14 +177,14 @@ module VX_lsu_unit import VX_gpu_pkg::*; #(
     wire                            mem_rsp_ready;
 
     assign mem_req_valid = lsu_valid;
-    assign lsu_ready = mem_req_ready 
+    assign lsu_ready = mem_req_ready
                    && (~mem_req_rw || st_rsp_ready); // writes commit directly
 
     for (genvar i = 0; i < NUM_LANES; ++i) begin
         assign mem_req_mask[i] = execute_if[0].data.tmask[i] && (~lsu_is_dup || (i == 0));
     end
 
-    assign mem_req_rw = ~execute_if[0].data.wb;    
+    assign mem_req_rw = ~execute_if[0].data.wb;
 
     wire mem_req_fire = mem_req_valid && mem_req_ready;
     wire mem_rsp_fire = mem_rsp_valid && mem_rsp_ready;
@@ -174,7 +195,7 @@ module VX_lsu_unit import VX_gpu_pkg::*; #(
 
     wire [NUM_LANES-1:0][REQ_ASHIFT-1:0] req_align;
 
-    for (genvar i = 0; i < NUM_LANES; ++i) begin  
+    for (genvar i = 0; i < NUM_LANES; ++i) begin
         assign req_align[i] = full_addr[i][REQ_ASHIFT-1:0];
         assign mem_req_addr[i] = full_addr[i][`MEM_ADDR_WIDTH-1:REQ_ASHIFT];
     end
@@ -184,7 +205,7 @@ module VX_lsu_unit import VX_gpu_pkg::*; #(
         always @(*) begin
             mem_req_byteen[i] = '0;
             case (`INST_LSU_WSIZE(execute_if[0].data.op_type))
-                0: begin // 8-bit   
+                0: begin // 8-bit
                     mem_req_byteen[i][req_align[i]] = 1'b1;
                 end
                 1: begin // 16 bit
@@ -206,9 +227,9 @@ module VX_lsu_unit import VX_gpu_pkg::*; #(
 
     // memory misalignment not supported!
     for (genvar i = 0; i < NUM_LANES; ++i) begin
-        wire lsu_req_fire = execute_if[0].valid && execute_if[0].ready;        
-        `RUNTIME_ASSERT((~lsu_req_fire || ~execute_if[0].data.tmask[i] || is_fence || (full_addr[i] % (1 << `INST_LSU_WSIZE(execute_if[0].data.op_type))) == 0), 
-            ("misaligned memory access, wid=%0d, PC=0x%0h, addr=0x%0h, wsize=%0d! (#%0d)", 
+        wire lsu_req_fire = execute_if[0].valid && execute_if[0].ready;
+        `RUNTIME_ASSERT((~lsu_req_fire || ~execute_if[0].data.tmask[i] || is_fence || (full_addr[i] % (1 << `INST_LSU_WSIZE(execute_if[0].data.op_type))) == 0),
+            ("misaligned memory access, wid=%0d, PC=0x%0h, addr=0x%0h, wsize=%0d! (#%0d)",
                 execute_if[0].data.wid, execute_if[0].data.PC, full_addr[i], `INST_LSU_WSIZE(execute_if[0].data.op_type), execute_if[0].data.uuid));
     end
 
@@ -231,7 +252,7 @@ module VX_lsu_unit import VX_gpu_pkg::*; #(
         end
     end
 
-    // track SOP/EOP for out-of-order memory responses  
+    // track SOP/EOP for out-of-order memory responses
 
     wire [LSUQ_SIZEW-1:0] pkt_waddr, pkt_raddr;
     wire mem_rsp_sop_pkt, mem_rsp_eop_pkt;
@@ -245,7 +266,6 @@ module VX_lsu_unit import VX_gpu_pkg::*; #(
         wire mem_req_rd_eop_fire = mem_req_rd_fire && execute_if[0].data.eop;
         wire mem_rsp_eop_fire    = mem_rsp_fire && mem_rsp_eop;
         wire full;
-        
         VX_allocator #(
             .SIZE (`LSUQ_SIZE)
         ) pkt_allocator (
@@ -262,7 +282,7 @@ module VX_lsu_unit import VX_gpu_pkg::*; #(
         wire rd_during_wr = mem_req_rd_fire && mem_rsp_eop_fire && (pkt_raddr == pkt_waddr);
 
         always @(posedge clk) begin
-            if (reset) begin                
+            if (reset) begin
                 pkt_ctr <= '0;
                 pkt_sop <= '0;
                 pkt_eop <= '0;
@@ -297,7 +317,7 @@ module VX_lsu_unit import VX_gpu_pkg::*; #(
         `UNUSED_VAR (mem_rsp_sop)
     end else begin
         assign pkt_waddr = 0;
-        assign mem_rsp_sop_pkt = mem_rsp_sop;        
+        assign mem_rsp_sop_pkt = mem_rsp_sop;
         assign mem_rsp_eop_pkt = mem_rsp_eop;
         `UNUSED_VAR (pkt_raddr)
     end
@@ -325,7 +345,7 @@ module VX_lsu_unit import VX_gpu_pkg::*; #(
 
     VX_mem_scheduler #(
         .INSTANCE_ID ($sformatf("core%0d-lsu-memsched", CORE_ID)),
-        .NUM_REQS    (LSU_MEM_REQS), 
+        .NUM_REQS    (LSU_MEM_REQS),
         .NUM_BANKS   (DCACHE_NUM_REQS),
         .ADDR_WIDTH  (DCACHE_ADDR_WIDTH),
         .DATA_WIDTH  (`XLEN),
@@ -350,7 +370,6 @@ module VX_lsu_unit import VX_gpu_pkg::*; #(
         .req_empty      (mem_req_empty),
         .req_ready      (mem_req_ready),
         `UNUSED_PIN     (write_notify),
-        
         // Output response
         .rsp_valid      (mem_rsp_valid),
         .rsp_mask       (mem_rsp_mask),
@@ -390,14 +409,14 @@ module VX_lsu_unit import VX_gpu_pkg::*; #(
     end
 
     // cache tag formatting: <uuid, tag, type>
-    
+
     for (genvar i = 0; i < DCACHE_NUM_REQS; ++i) begin
         wire [`UUID_WIDTH-1:0]                          cache_req_uuid, cache_rsp_uuid;
-        wire [NUM_LANES-1:0][`CACHE_ADDR_TYPE_BITS-1:0] cache_req_type, cache_rsp_type;        
+        wire [NUM_LANES-1:0][`CACHE_ADDR_TYPE_BITS-1:0] cache_req_type, cache_rsp_type;
         wire [`CLOG2(`LSUQ_SIZE)-1:0]                   cache_req_tag_x, cache_rsp_tag_x;
         if (DCACHE_NUM_BATCHES > 1) begin
 
-            wire [DCACHE_NUM_BATCHES-1:0][`CACHE_ADDR_TYPE_BITS-1:0] cache_req_type_b, cache_rsp_type_b;            
+            wire [DCACHE_NUM_BATCHES-1:0][`CACHE_ADDR_TYPE_BITS-1:0] cache_req_type_b, cache_rsp_type_b;
             wire [`CACHE_ADDR_TYPE_BITS-1:0] cache_req_type_bi, cache_rsp_type_bi;
             wire [DCACHE_BATCH_SEL_BITS-1:0] cache_req_bid, cache_rsp_bid;
 
@@ -410,7 +429,7 @@ module VX_lsu_unit import VX_gpu_pkg::*; #(
             assign cache_rsp_tag[i] = {cache_rsp_uuid, cache_rsp_type, cache_rsp_bid, cache_rsp_tag_x};
 
             for (genvar j = 0; j < DCACHE_NUM_BATCHES; ++j) begin
-                localparam k = j * DCACHE_NUM_REQS + i;                
+                localparam k = j * DCACHE_NUM_REQS + i;
                 if (k < NUM_LANES) begin
                     assign cache_req_type_b[j] = cache_req_type[k];
                     assign cache_rsp_type[k] = cache_rsp_type_b[j];
@@ -421,12 +440,11 @@ module VX_lsu_unit import VX_gpu_pkg::*; #(
             end
 
         end else begin
-            
             assign {cache_req_uuid, cache_req_type, cache_req_tag_x} = cache_req_tag[i];
             assign cache_bus_if[i].req_data.tag = {cache_req_uuid, cache_req_tag_x, cache_req_type[i]};
 
             assign {cache_rsp_uuid, cache_rsp_tag_x, cache_rsp_type[i]} = cache_bus_if[i].rsp_data.tag;
-            assign cache_rsp_tag[i] = {cache_rsp_uuid, cache_rsp_type, cache_rsp_tag_x};        
+            assign cache_rsp_tag[i] = {cache_rsp_uuid, cache_rsp_type, cache_rsp_tag_x};
 
             for (genvar j = 0; j < DCACHE_NUM_REQS; ++j) begin
                 if (i != j) begin
@@ -436,7 +454,6 @@ module VX_lsu_unit import VX_gpu_pkg::*; #(
             end
         end
     end
-    
     wire [`UUID_WIDTH-1:0] rsp_uuid;
     wire [NUM_LANES-1:0][`CACHE_ADDR_TYPE_BITS-1:0] rsp_addr_type;
     wire [`NW_WIDTH-1:0] rsp_wid;
@@ -447,7 +464,6 @@ module VX_lsu_unit import VX_gpu_pkg::*; #(
     wire [NUM_LANES-1:0][REQ_ASHIFT-1:0] rsp_align;
     wire [PID_WIDTH-1:0] rsp_pid;
     wire rsp_is_dup;
-    
 `ifndef LSU_DUP_ENABLE
     assign rsp_is_dup = 0;
 `endif
@@ -482,7 +498,7 @@ module VX_lsu_unit import VX_gpu_pkg::*; #(
                                                           (rsp_align[i][2] ? mem_rsp_data[i][63:32] : mem_rsp_data[i][31:0]);
     `else
         wire [31:0] rsp_data32 = (i == 0 || rsp_is_dup) ? mem_rsp_data[0] : mem_rsp_data[i];
-    `endif        
+    `endif
         wire [15:0] rsp_data16 = rsp_align[i][1] ? rsp_data32[31:16] : rsp_data32[15:0];
         wire [7:0]  rsp_data8  = rsp_align[i][0] ? rsp_data16[15:8] : rsp_data16[7:0];
 
@@ -492,7 +508,7 @@ module VX_lsu_unit import VX_gpu_pkg::*; #(
             `INST_FMT_H:  rsp_data[i] = `XLEN'(signed'(rsp_data16));
             `INST_FMT_BU: rsp_data[i] = `XLEN'(unsigned'(rsp_data8));
             `INST_FMT_HU: rsp_data[i] = `XLEN'(unsigned'(rsp_data16));
-        `ifdef XLEN_64            
+        `ifdef XLEN_64
             `INST_FMT_W:  rsp_data[i] = rsp_is_float ? (`XLEN'(rsp_data32) | 64'hffffffff00000000) : `XLEN'(signed'(rsp_data32));
             `INST_FMT_WU: rsp_data[i] = `XLEN'(unsigned'(rsp_data32));
             `INST_FMT_D:  rsp_data[i] = `XLEN'(signed'(rsp_data64));
@@ -501,10 +517,11 @@ module VX_lsu_unit import VX_gpu_pkg::*; #(
         `endif
             default: rsp_data[i] = 'x;
             endcase
-        end        
-    end   
+        end
+    end
 
     assign rsp_tmask = rsp_is_dup ? rsp_tmask_uq : mem_rsp_mask;
+
 
     // load commit
 
@@ -544,7 +561,6 @@ module VX_lsu_unit import VX_gpu_pkg::*; #(
     assign commit_st_if.data.data = commit_ld_if.data.data; // force arbiter passthru
 
     // lsu commit
-    
     `RESET_RELAY (commit_reset, reset);
 
     VX_commit_if #(
@@ -562,8 +578,8 @@ module VX_lsu_unit import VX_gpu_pkg::*; #(
         .ready_in  ({commit_st_if.ready, commit_ld_if.ready}),
         .data_in   ({commit_st_if.data, commit_ld_if.data}),
         .data_out  (commit_arb_if[0].data),
-        .valid_out (commit_arb_if[0].valid), 
-        .ready_out (commit_arb_if[0].ready),        
+        .valid_out (commit_arb_if[0].valid),
+        .ready_out (commit_arb_if[0].ready),
         `UNUSED_PIN (sel_out)
     );
 
@@ -577,6 +593,22 @@ module VX_lsu_unit import VX_gpu_pkg::*; #(
         .commit_in_if  (commit_arb_if),
         .commit_out_if (commit_if)
     );
+// Mod4 set control for mload partial operations
+always @(posedge clk) begin
+    if (reset) begin
+        mload_finished <= 2b'0;
+    end else begin
+        // Add 1 for the first partial load
+        mload_finished <= mload_finished + 3'((execute_if[0].data.op_type == `INST_MLOAD) && mem_rsp_fire);
+
+        // TODO be sure of this
+        // Reset the counter after the last partial load
+        if (mload_finished == 3'h4) begin
+            mload_finished <= 3'b0;
+        end
+    end
+end
+
 
 `ifdef DBG_SCOPE_LSU
     if (CORE_ID == 0) begin
@@ -596,7 +628,7 @@ module VX_lsu_unit import VX_gpu_pkg::*; #(
             .bus_out(scope_bus_out)
         );
     `endif
-    `ifdef CHIPSCOPE    
+    `ifdef CHIPSCOPE
         wire [31:0] full_addr_0 = full_addr[0];
         wire [31:0] mem_req_data_0 = mem_req_data[0];
         wire [31:0] rsp_data_0 = rsp_data[0];
@@ -612,9 +644,9 @@ module VX_lsu_unit import VX_gpu_pkg::*; #(
 `else
     `SCOPE_IO_UNUSED()
 `endif
-  
+
 `ifdef DBG_TRACE_CORE_DCACHE
-    always @(posedge clk) begin    
+    always @(posedge clk) begin
         if (execute_if[0].valid && fence_wait) begin
             `TRACE(1, ("%d: *** D$%0d fence wait\n", $time, CORE_ID));
         end
@@ -643,5 +675,4 @@ module VX_lsu_unit import VX_gpu_pkg::*; #(
         end
     end
 `endif
-    
 endmodule

--- a/hw/rtl/core/VX_lsu_unit.sv
+++ b/hw/rtl/core/VX_lsu_unit.sv
@@ -102,9 +102,9 @@ module VX_lsu_unit import VX_gpu_pkg::*; #(
         wire [`XLEN-1:0] addr_offset_2;
 
         // First matrix accesses have offset (tid / 2) * 2
-        assign addr_offset_1 = (`XLEN)'(execute_if[0].data.tid) >> 1 << 1;
+        assign addr_offset_1 = (`XLEN)'(i) >> 1 << 1;
         // Second matrix accesses have offset (tid % 2)
-        assign addr_offset_2 = (`XLEN)'(execute_if[0].data.tid[0]);
+        assign addr_offset_2 = (`XLEN)'(i[0]);
 
         always @(*) begin
             if (is_mload) begin

--- a/hw/rtl/core/VX_muldiv_unit.sv
+++ b/hw/rtl/core/VX_muldiv_unit.sv
@@ -323,16 +323,16 @@ module VX_muldiv_unit #(
 
     VX_stream_arb #(
         .NUM_INPUTS (2),
-        .DATAW (TAGW + (NUM_LANES * `XLEN)),
+        .DATAW (TAGW + (NUM_LANES * `XLEN) + 1),
         .OUT_REG (1)
     ) rsp_buf (
         .clk       (clk),
         .reset     (reset),
         .valid_in  ({div_valid_out, mul_valid_out}),
         .ready_in  ({div_ready_out, mul_ready_out}),
-        .data_in   ({{div_uuid_out, div_wid_out, div_tmask_out, div_PC_out, div_rd_out, div_wb_out, div_pid_out, div_sop_out, div_eop_out, div_result_out},
-                     {mul_uuid_out, mul_wid_out, mul_tmask_out, mul_PC_out, mul_rd_out, mul_wb_out, mul_pid_out, mul_sop_out, mul_eop_out, mul_result_out}}),
-        .data_out  ({commit_if.data.uuid, commit_if.data.wid, commit_if.data.tmask, commit_if.data.PC, commit_if.data.rd, commit_if.data.wb, commit_if.data.pid, commit_if.data.sop, commit_if.data.eop, commit_if.data.data}),
+        .data_in   ({{div_uuid_out, div_wid_out, div_tmask_out, div_PC_out, div_rd_out, div_wb_out, div_pid_out, div_sop_out, div_eop_out, div_result_out, 1'b1},
+                     {mul_uuid_out, mul_wid_out, mul_tmask_out, mul_PC_out, mul_rd_out, mul_wb_out, mul_pid_out, mul_sop_out, mul_eop_out, mul_result_out, 1'b1}}),
+        .data_out  ({commit_if.data.uuid, commit_if.data.wid, commit_if.data.tmask, commit_if.data.PC, commit_if.data.rd, commit_if.data.wb, commit_if.data.pid, commit_if.data.sop, commit_if.data.eop, commit_if.data.data, commit_if.data.true_eop}),
         .valid_out (commit_if.valid),
         .ready_out (commit_if.ready),
         `UNUSED_PIN (sel_out)

--- a/hw/rtl/core/VX_operands.sv
+++ b/hw/rtl/core/VX_operands.sv
@@ -25,7 +25,7 @@ module VX_operands import VX_gpu_pkg::*; #(
     VX_operands_if.master   operands_if [`ISSUE_WIDTH]
 );
     `UNUSED_PARAM (CORE_ID)
-    localparam DATAW = `UUID_WIDTH + ISSUE_WIS_W + `NUM_THREADS + `XLEN + 1 + `EX_BITS + `INST_OP_BITS + `INST_MOD_BITS + 1 + 1 + `XLEN + `NR_BITS;
+    localparam DATAW = `UUID_WIDTH + ISSUE_WIS_W + `NUM_THREADS + `XLEN + `EX_BITS + `INST_OP_BITS + `INST_MOD_BITS + 1 + 1 + 1 + `XLEN + `NR_BITS;
     localparam RAM_ADDRW = `LOG2UP(`NUM_REGS * ISSUE_RATIO);
 
     localparam STATE_IDLE   = 2'd0;
@@ -207,7 +207,7 @@ module VX_operands import VX_gpu_pkg::*; #(
                 scoreboard_if[i].data.uuid,
                 scoreboard_if[i].data.wis,
                 scoreboard_if[i].data.tmask,
-                scoreboard_if[i].data.PC, 
+                scoreboard_if[i].data.PC,
                 scoreboard_if[i].data.wb,
                 scoreboard_if[i].data.ex_type,
                 scoreboard_if[i].data.op_type,
@@ -223,7 +223,7 @@ module VX_operands import VX_gpu_pkg::*; #(
                 operands_if[i].data.uuid,
                 operands_if[i].data.wis,
                 operands_if[i].data.tmask,
-                operands_if[i].data.PC, 
+                operands_if[i].data.PC,
                 operands_if[i].data.wb,
                 operands_if[i].data.ex_type,
                 operands_if[i].data.op_type,
@@ -242,7 +242,7 @@ module VX_operands import VX_gpu_pkg::*; #(
 
         // GPR banks
 
-        reg [RAM_ADDRW-1:0] gpr_rd_addr;       
+        reg [RAM_ADDRW-1:0] gpr_rd_addr;
         wire [RAM_ADDRW-1:0] gpr_wr_addr;
         if (ISSUE_WIS != 0) begin
             assign gpr_wr_addr = {writeback_if[i].data.wis, writeback_if[i].data.rd};

--- a/hw/rtl/core/VX_schedule.sv
+++ b/hw/rtl/core/VX_schedule.sv
@@ -72,8 +72,8 @@ module VX_schedule import VX_gpu_pkg::*; #(
     wire schedule_if_fire = schedule_if.valid && schedule_if.ready;
 
     // branch
-    wire [`NUM_ALU_BLOCKS-1:0]                  branch_valid;    
-    wire [`NUM_ALU_BLOCKS-1:0][`NW_WIDTH-1:0]   branch_wid;    
+    wire [`NUM_ALU_BLOCKS-1:0]                  branch_valid;
+    wire [`NUM_ALU_BLOCKS-1:0][`NW_WIDTH-1:0]   branch_wid;
     wire [`NUM_ALU_BLOCKS-1:0]                  branch_taken;
     wire [`NUM_ALU_BLOCKS-1:0][`XLEN-1:0]       branch_dest;
     for (genvar i = 0; i < `NUM_ALU_BLOCKS; ++i) begin
@@ -87,7 +87,7 @@ module VX_schedule import VX_gpu_pkg::*; #(
     reg [`NUM_BARRIERS-1:0][`NUM_WARPS-1:0] barrier_masks, barrier_masks_n;
     reg [`NUM_WARPS-1:0] barrier_stalls, barrier_stalls_n;
     wire [`CLOG2(`NUM_WARPS+1)-1:0] active_barrier_count;
-    wire [`NUM_WARPS-1:0] curr_barrier_mask;    
+    wire [`NUM_WARPS-1:0] curr_barrier_mask;
 `ifdef GBAR_ENABLE
     reg [`NUM_WARPS-1:0] curr_barrier_mask_n;
     reg gbar_req_valid;
@@ -387,7 +387,7 @@ module VX_schedule import VX_gpu_pkg::*; #(
     end
     `RUNTIME_ASSERT(timeout_ctr < `STALL_TIMEOUT, ("%t: *** core%0d-scheduler-timeout: stalled_warps=%b", $time, CORE_ID, stalled_warps));
 
-`ifdef PERF_ENABLE    
+`ifdef PERF_ENABLE
     reg [`PERF_CTR_BITS-1:0] perf_sched_idles;
     reg [`PERF_CTR_BITS-1:0] perf_sched_stalls;
 
@@ -397,7 +397,7 @@ module VX_schedule import VX_gpu_pkg::*; #(
     always @(posedge clk) begin
         if (reset) begin
             perf_sched_idles  <= '0;
-            perf_sched_stalls <= '0;            
+            perf_sched_stalls <= '0;
         end else begin
             perf_sched_idles  <= perf_sched_idles + `PERF_CTR_BITS'(schedule_idle);
             perf_sched_stalls <= perf_sched_stalls + `PERF_CTR_BITS'(schedule_stall);
@@ -405,7 +405,7 @@ module VX_schedule import VX_gpu_pkg::*; #(
     end
 
     assign perf_schedule_if.sched_idles = perf_sched_idles;
-    assign perf_schedule_if.sched_stalls = perf_sched_stalls;    
+    assign perf_schedule_if.sched_stalls = perf_sched_stalls;
 `endif
 
 endmodule

--- a/hw/rtl/core/VX_schedule.sv
+++ b/hw/rtl/core/VX_schedule.sv
@@ -152,7 +152,7 @@ module VX_schedule import VX_gpu_pkg::*; #(
     `endif
         if (warp_ctl_if.valid && warp_ctl_if.barrier.valid) begin
             if (~warp_ctl_if.barrier.is_global 
-             && (active_barrier_count[`NW_WIDTH-1:0] == warp_ctl_if.barrier.size_m1[`NW_WIDTH-1:0])) begin                                
+             && (active_barrier_count[`NW_WIDTH-1:0] == warp_ctl_if.barrier.size_m1[`NW_WIDTH-1:0])) begin
                 barrier_masks_n[warp_ctl_if.barrier.id] = '0;
                 barrier_stalls_n &= ~barrier_masks[warp_ctl_if.barrier.id];
             end else begin
@@ -353,7 +353,7 @@ module VX_schedule import VX_gpu_pkg::*; #(
         .reset     (pending_instr_reset),
         .incr      (schedule_if_fire),
         .incr_wid  (schedule_if.data.wid),
-        .decr      (commit_sched_if.committed),
+        .decr      (commit_sched_if.committed & {(`ISSUE_WIDTH){commit_sched_if.true_eop}}),
         .decr_wid  (commit_sched_if.committed_wid),
         .alm_empty_wid (sched_csr_if.alm_empty_wid),
         .alm_empty (sched_csr_if.alm_empty),

--- a/hw/rtl/core/VX_scoreboard.sv
+++ b/hw/rtl/core/VX_scoreboard.sv
@@ -219,8 +219,19 @@ module VX_scoreboard import VX_gpu_pkg::*; #(
                 end else if (ibuffer_if[i].valid && ibuffer_if[i].ready) begin
                     timeout_ctr <= '0;
                 end
+
+                `ifdef DBG_TRACE_CORE_PIPELINE
+                    if (writeback_if[i].valid) begin
+                        `TRACE(1, ("%d: *** core%0d-scoreboard-writeback: wid=%0d, PC=0x%0h, tmask=%b, rd=%d, sop=%b, eop=%b, data=",
+                            $time, CORE_ID, wis_to_wid(writeback_if[i].data.wis, i), writeback_if[i].data.PC, writeback_if[i].data.tmask, writeback_if[i].data.rd, writeback_if[i].data.sop, writeback_if[i].data.eop));
+                         
+                        `TRACE_ARRAY1D(1, writeback_if[i].data, `ISSUE_WIDTH);
+                        `TRACE(1,  ("(#%0d)\n", writeback_if[i].data.uuid));
+                    end
+                `endif
             end
         end
+
         `RUNTIME_ASSERT((timeout_ctr < `STALL_TIMEOUT),
                         ("%t: *** core%0d-scoreboard-timeout: wid=%0d, PC=0x%0h, tmask=%b, cycles=%0d, inuse=%b (#%0d)",
                             $time, CORE_ID, wis_to_wid(ibuffer_if[i].data.wis, i), ibuffer_if[i].data.PC, ibuffer_if[i].data.tmask, timeout_ctr,

--- a/hw/rtl/core/VX_sfu_unit.sv
+++ b/hw/rtl/core/VX_sfu_unit.sv
@@ -44,7 +44,7 @@ module VX_sfu_unit import VX_gpu_pkg::*; #(
     localparam PID_BITS     = `CLOG2(`NUM_THREADS / NUM_LANES);
     localparam PID_WIDTH    = `UP(PID_BITS);
 
-    localparam RSP_ARB_DATAW = `UUID_WIDTH + `NW_WIDTH + NUM_LANES + (NUM_LANES * `XLEN) + `NR_BITS + 1 + `XLEN + PID_WIDTH + 1 + 1;
+    localparam RSP_ARB_DATAW = `UUID_WIDTH + `NW_WIDTH + NUM_LANES + (NUM_LANES * `XLEN) + `NR_BITS + 1 + `XLEN + PID_WIDTH + 1 + 1 + 1;
     localparam RSP_ARB_SIZE = 1 + 1;
     localparam RSP_ARB_IDX_WCTL = 0;
     localparam RSP_ARB_IDX_CSRS = 1;

--- a/hw/rtl/core/VX_sfu_unit.sv
+++ b/hw/rtl/core/VX_sfu_unit.sv
@@ -44,7 +44,7 @@ module VX_sfu_unit import VX_gpu_pkg::*; #(
     localparam PID_BITS     = `CLOG2(`NUM_THREADS / NUM_LANES);
     localparam PID_WIDTH    = `UP(PID_BITS);
 
-    localparam RSP_ARB_DATAW = `UUID_WIDTH + `NW_WIDTH + NUM_LANES + (NUM_LANES * `XLEN) + `NR_BITS + 1 + `XLEN + PID_WIDTH + 1 + 1 + `NT_BITS + 1 + 1;
+    localparam RSP_ARB_DATAW = `UUID_WIDTH + `NW_WIDTH + NUM_LANES + (NUM_LANES * `XLEN) + `NR_BITS + 1 + `XLEN + PID_WIDTH + 1 + 1;
     localparam RSP_ARB_SIZE = 1 + 1;
     localparam RSP_ARB_IDX_WCTL = 0;
     localparam RSP_ARB_IDX_CSRS = 1;

--- a/hw/rtl/core/VX_sfu_unit.sv
+++ b/hw/rtl/core/VX_sfu_unit.sv
@@ -15,7 +15,7 @@
 
 module VX_sfu_unit import VX_gpu_pkg::*; #(
     parameter CORE_ID = 0
-) (    
+) (
     input wire              clk,
     input wire              reset,
 
@@ -28,7 +28,6 @@ module VX_sfu_unit import VX_gpu_pkg::*; #(
 
     // Inputs
     VX_dispatch_if.slave    dispatch_if [`ISSUE_WIDTH],
-    
 `ifdef EXT_F_ENABLE
     VX_fpu_to_csr_if.slave  fpu_to_csr_if [`NUM_FPU_BLOCKS],
 `endif
@@ -37,7 +36,7 @@ module VX_sfu_unit import VX_gpu_pkg::*; #(
     VX_commit_if.master     commit_if [`ISSUE_WIDTH],
     VX_commit_csr_if.slave  commit_csr_if,
     VX_sched_csr_if.slave   sched_csr_if,
-    VX_warp_ctl_if.master   warp_ctl_if    
+    VX_warp_ctl_if.master   warp_ctl_if
 );
     `UNUSED_PARAM (CORE_ID)
     localparam BLOCK_SIZE   = 1;
@@ -45,7 +44,7 @@ module VX_sfu_unit import VX_gpu_pkg::*; #(
     localparam PID_BITS     = `CLOG2(`NUM_THREADS / NUM_LANES);
     localparam PID_WIDTH    = `UP(PID_BITS);
 
-    localparam RSP_ARB_DATAW = `UUID_WIDTH + `NW_WIDTH + NUM_LANES + (NUM_LANES * `XLEN) + `NR_BITS + 1 + `XLEN + PID_WIDTH + 1 + 1;
+    localparam RSP_ARB_DATAW = `UUID_WIDTH + `NW_WIDTH + NUM_LANES + (NUM_LANES * `XLEN) + `NR_BITS + 1 + `XLEN + PID_WIDTH + 1 + 1 + `NT_BITS + 1 + 1;
     localparam RSP_ARB_SIZE = 1 + 1;
     localparam RSP_ARB_IDX_WCTL = 0;
     localparam RSP_ARB_IDX_CSRS = 1;
@@ -155,7 +154,6 @@ module VX_sfu_unit import VX_gpu_pkg::*; #(
     assign execute_if[0].ready = sfu_req_ready;
 
     // response arbitration
-    
     `RESET_RELAY (commit_reset, reset);
 
     VX_commit_if #(
@@ -178,6 +176,7 @@ module VX_sfu_unit import VX_gpu_pkg::*; #(
         .ready_out (arb_commit_if[0].ready),
         `UNUSED_PIN (sel_out)
     );
+
 
     VX_gather_unit #(
         .BLOCK_SIZE (BLOCK_SIZE),

--- a/hw/rtl/core/VX_trace.vh
+++ b/hw/rtl/core/VX_trace.vh
@@ -173,6 +173,7 @@ task trace_ex_op(input int level,
                 `INST_LSU_SW: `TRACE(level, ("SW"));
                 `INST_LSU_SD: `TRACE(level, ("SD"));
                 `INST_LSU_FENCE:`TRACE(level,("FENCE"));
+                `INST_LSU_MLOAD:  `TRACE(level,("MLOAD"));
                 default:      `TRACE(level, ("?"));
             endcase
         end

--- a/hw/rtl/core/VX_wctl_unit.sv
+++ b/hw/rtl/core/VX_wctl_unit.sv
@@ -32,7 +32,7 @@ module VX_wctl_unit import VX_gpu_pkg::*; #(
     localparam PID_BITS   = `CLOG2(`NUM_THREADS / NUM_LANES);
     localparam PID_WIDTH  = `UP(PID_BITS);
     localparam WCTL_WIDTH = $bits(tmc_t) + $bits(wspawn_t) + $bits(split_t) + $bits(join_t) + $bits(barrier_t);
-    localparam DATAW = `UUID_WIDTH + `NW_WIDTH + NUM_LANES + `XLEN + `NR_BITS + 1 + WCTL_WIDTH + PID_WIDTH + 1 + 1;
+    localparam DATAW = `UUID_WIDTH + `NW_WIDTH + NUM_LANES + `XLEN + `NR_BITS + 1 + WCTL_WIDTH + PID_WIDTH + 1 + 1 + 1;
 
     `UNUSED_VAR (execute_if.data.rs3_data)
     
@@ -135,8 +135,8 @@ module VX_wctl_unit import VX_gpu_pkg::*; #(
         .reset     (reset),
         .valid_in  (execute_if.valid),
         .ready_in  (execute_if.ready),
-        .data_in   ({execute_if.data.uuid, execute_if.data.wid, execute_if.data.tmask, execute_if.data.PC, execute_if.data.rd, execute_if.data.wb, execute_if.data.pid, execute_if.data.sop, execute_if.data.eop, {tmc, wspawn, split, sjoin, barrier}}),
-        .data_out  ({commit_if.data.uuid, commit_if.data.wid, commit_if.data.tmask, commit_if.data.PC, commit_if.data.rd, commit_if.data.wb, commit_if.data.pid, commit_if.data.sop, commit_if.data.eop, {tmc_r, wspawn_r, split_r, sjoin_r, barrier_r}}),
+        .data_in   ({execute_if.data.uuid, execute_if.data.wid, execute_if.data.tmask, execute_if.data.PC, execute_if.data.rd, execute_if.data.wb, execute_if.data.pid, execute_if.data.sop, execute_if.data.eop, 1'b1, {tmc, wspawn, split, sjoin, barrier}}),
+        .data_out  ({commit_if.data.uuid, commit_if.data.wid, commit_if.data.tmask, commit_if.data.PC, commit_if.data.rd, commit_if.data.wb, commit_if.data.pid, commit_if.data.sop, commit_if.data.eop, commit_if.data.true_eop, {tmc_r, wspawn_r, split_r, sjoin_r, barrier_r}}),
         .valid_out (commit_if.valid),
         .ready_out (commit_if.ready)
     );
@@ -151,6 +151,7 @@ module VX_wctl_unit import VX_gpu_pkg::*; #(
     
     for (genvar i = 0; i < NUM_LANES; ++i) begin
         assign commit_if.data.data[i] = `XLEN'(split_r.is_dvg);
+        assign commit_if.data.true_eop = 1'b1;
     end
 
 endmodule

--- a/hw/rtl/interfaces/VX_commit_if.sv
+++ b/hw/rtl/interfaces/VX_commit_if.sv
@@ -17,7 +17,6 @@ interface VX_commit_if #(
     parameter NUM_LANES = `NUM_THREADS,
     parameter PID_WIDTH = `LOG2UP(`NUM_THREADS / NUM_LANES)
 ) ();
-    
     typedef struct packed {
         logic [`UUID_WIDTH-1:0]     uuid;
         logic [`NW_WIDTH-1:0]       wid;
@@ -29,11 +28,13 @@ interface VX_commit_if #(
         logic [PID_WIDTH-1:0]       pid;
         logic                       sop;
         logic                       eop;
+        logic [`NT_BITS:0]          microop_id;
+        logic                       is_microop;
     } data_t;
 
     logic  valid;
     data_t data;
-    logic  ready;    
+    logic  ready;
 
     modport master (
         output valid,

--- a/hw/rtl/interfaces/VX_commit_if.sv
+++ b/hw/rtl/interfaces/VX_commit_if.sv
@@ -28,8 +28,6 @@ interface VX_commit_if #(
         logic [PID_WIDTH-1:0]       pid;
         logic                       sop;
         logic                       eop;
-        logic [`NT_BITS:0]          microop_id;
-        logic                       is_microop;
     } data_t;
 
     logic  valid;

--- a/hw/rtl/interfaces/VX_commit_if.sv
+++ b/hw/rtl/interfaces/VX_commit_if.sv
@@ -28,6 +28,7 @@ interface VX_commit_if #(
         logic [PID_WIDTH-1:0]       pid;
         logic                       sop;
         logic                       eop;
+        logic                       true_eop;
     } data_t;
 
     logic  valid;

--- a/hw/rtl/interfaces/VX_commit_sched_if.sv
+++ b/hw/rtl/interfaces/VX_commit_sched_if.sv
@@ -17,14 +17,17 @@ interface VX_commit_sched_if ();
 
     wire [`ISSUE_WIDTH-1:0] committed;
     wire [`ISSUE_WIDTH-1:0][`NW_WIDTH-1:0] committed_wid;
+    wire true_eop;
 
     modport master (
         output committed,
+        output true_eop,
         output committed_wid
     );
 
     modport slave (
         input committed,
+        input true_eop,
         input committed_wid
     );
 

--- a/hw/rtl/interfaces/VX_execute_if.sv
+++ b/hw/rtl/interfaces/VX_execute_if.sv
@@ -18,9 +18,9 @@ interface VX_execute_if #(
     parameter PID_WIDTH = `LOG2UP(`NUM_THREADS / NUM_LANES)
 ) ();
     typedef struct packed {
-        logic [`UUID_WIDTH-1:0]         uuid;                
+        logic [`UUID_WIDTH-1:0]         uuid;
         logic [`NW_WIDTH-1:0]           wid;
-        logic [NUM_LANES-1:0]           tmask;       
+        logic [NUM_LANES-1:0]           tmask;
         logic [`INST_ALU_BITS-1:0]      op_type;
         logic [`INST_MOD_BITS-1:0]      op_mod;
         logic                           wb;

--- a/hw/rtl/interfaces/VX_fetch_if.sv
+++ b/hw/rtl/interfaces/VX_fetch_if.sv
@@ -26,7 +26,7 @@ interface VX_fetch_if ();
     logic  valid;
     data_t data;
     logic  ready;
-`ifndef L1_ENABLE    
+`ifndef L1_ENABLE
     logic [`ISSUE_WIDTH-1:0] ibuf_pop;
 `endif
 

--- a/hw/rtl/interfaces/VX_ibuffer_if.sv
+++ b/hw/rtl/interfaces/VX_ibuffer_if.sv
@@ -1,10 +1,10 @@
 // Copyright © 2019-2023
-// 
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 // http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -19,9 +19,9 @@ interface VX_ibuffer_if import VX_gpu_pkg::*; ();
         logic [`UUID_WIDTH-1:0]     uuid;
         logic [ISSUE_WIS_W-1:0]     wis;
         logic [`NUM_THREADS-1:0]    tmask;
-        logic [`EX_BITS-1:0]        ex_type;    
+        logic [`EX_BITS-1:0]        ex_type;
         logic [`INST_OP_BITS-1:0]   op_type;
-        logic [`INST_MOD_BITS-1:0]  op_mod;    
+        logic [`INST_MOD_BITS-1:0]  op_mod;
         logic                       wb;
         logic                       use_PC;
         logic                       use_imm;

--- a/hw/rtl/interfaces/VX_operands_if.sv
+++ b/hw/rtl/interfaces/VX_operands_if.sv
@@ -36,7 +36,6 @@ interface VX_operands_if import VX_gpu_pkg::*; ();
     logic  valid;
     data_t data;
     logic  ready;
-    
     modport master (
         output valid,
         output data,

--- a/hw/rtl/interfaces/VX_writeback_if.sv
+++ b/hw/rtl/interfaces/VX_writeback_if.sv
@@ -24,10 +24,6 @@ interface VX_writeback_if import VX_gpu_pkg::*; ();
         logic [`NUM_THREADS-1:0][`XLEN-1:0] data;
         logic                           sop;
         logic                           eop;
-       /* verilator lint_off UNUSED */
-        logic [`NT_BITS:0]              microop_id;
-       /* verilator lint_off UNUSED */
-        logic                           is_microop;
     } data_t;
 
     logic  valid;

--- a/hw/rtl/interfaces/VX_writeback_if.sv
+++ b/hw/rtl/interfaces/VX_writeback_if.sv
@@ -24,6 +24,10 @@ interface VX_writeback_if import VX_gpu_pkg::*; ();
         logic [`NUM_THREADS-1:0][`XLEN-1:0] data;
         logic                           sop;
         logic                           eop;
+       /* verilator lint_off UNUSED */
+        logic [`NT_BITS:0]              microop_id;
+       /* verilator lint_off UNUSED */
+        logic                           is_microop;
     } data_t;
 
     logic  valid;

--- a/hw/rtl/libs/VX_reduce.sv
+++ b/hw/rtl/libs/VX_reduce.sv
@@ -1,10 +1,10 @@
 // Copyright © 2019-2023
-// 
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 // http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -14,7 +14,7 @@
 `include "VX_platform.vh"
 
 `TRACING_OFF
-module VX_reduce #(    
+module VX_reduce #(
     parameter DATAW_IN   = 1,
     parameter DATAW_OUT  = DATAW_IN,
     parameter N          = 1,
@@ -42,22 +42,22 @@ module VX_reduce #(
         end
 
         VX_reduce #(
-            .DATAW_IN  (DATAW_IN), 
+            .DATAW_IN  (DATAW_IN),
             .DATAW_OUT (DATAW_OUT),
             .N  (N_A),
             .OP (OP)
         ) reduce_A (
-            .data_in  (in_A), 
+            .data_in  (in_A),
             .data_out (out_A)
         );
 
         VX_reduce #(
-            .DATAW_IN  (DATAW_IN), 
+            .DATAW_IN  (DATAW_IN),
             .DATAW_OUT (DATAW_OUT),
             .N  (N_B),
             .OP (OP)
         ) reduce_B (
-            .data_in  (in_B), 
+            .data_in  (in_B),
             .data_out (out_B)
         );
 
@@ -67,6 +67,5 @@ module VX_reduce #(
         else if (OP == "|") assign data_out = out_A | out_B;
         else `ERROR(("invalid parameter"));
     end
-  
 endmodule
 `TRACING_ON

--- a/kernel/include/vx_intrinsics.h
+++ b/kernel/include/vx_intrinsics.h
@@ -157,7 +157,11 @@ inline void vx_barrier(unsigned barried_id, unsigned num_warps) {
 inline void vx_mload(int* input, int* weights) {
     // Load input and weights matrices
     //             .insn r opcode6, func3, func7, rd, rs1, rs2
-    asm volatile (".insn r %0, 0, 0, x1, %1, %2" :: "i"(RISCV_CUSTOM2), "r"(input), "r"(weights));
+    // int ret;
+    // asm volatile (".insn r %1, 0, 0, %0, %2, %3" : "=r"(ret) : "i"(RISCV_CUSTOM2), "r"(input), "r"(weights));
+    // return ret;
+
+    asm volatile (".insn r %0, 0, 0, x28, %1, %2" :: "i"(RISCV_CUSTOM2), "r"(input), "r"(weights));
 }
 
 // Return current thread identifier

--- a/kernel/include/vx_intrinsics.h
+++ b/kernel/include/vx_intrinsics.h
@@ -153,6 +153,13 @@ inline void vx_barrier(unsigned barried_id, unsigned num_warps) {
     asm volatile (".insn r %0, 4, 0, x0, %1, %2" :: "i"(RISCV_CUSTOM0), "r"(barried_id), "r"(num_warps));
 }
 
+// Mod 0 
+inline void vx_mload(int input[32], int weights[32]) {
+    // Load input and weights matrices
+    //             .insn r opcode6, func3, func7, rd, rs1, rs2
+    asm volatile (".insn r %0, 0, 0, 1, %1, %2" :: "i"(RISCV_CUSTOM2), "r"(input), "r"(weights));
+}
+
 // Return current thread identifier
 inline int vx_thread_id() {
     int ret;

--- a/kernel/include/vx_intrinsics.h
+++ b/kernel/include/vx_intrinsics.h
@@ -154,10 +154,10 @@ inline void vx_barrier(unsigned barried_id, unsigned num_warps) {
 }
 
 // Mod 0 
-inline void vx_mload(int32_t* input, int32_t* weights) {
+inline void vx_mload(int* input, int* weights) {
     // Load input and weights matrices
     //             .insn r opcode6, func3, func7, rd, rs1, rs2
-    asm volatile (".insn r %0, 0, 0, 1, %1, %2" :: "i"(RISCV_CUSTOM2), "r"(input), "r"(weights));
+    asm volatile (".insn r %0, 0, 0, x1, %1, %2" :: "i"(RISCV_CUSTOM2), "r"(input), "r"(weights));
 }
 
 // Return current thread identifier

--- a/kernel/include/vx_intrinsics.h
+++ b/kernel/include/vx_intrinsics.h
@@ -153,7 +153,7 @@ inline void vx_barrier(unsigned barried_id, unsigned num_warps) {
     asm volatile (".insn r %0, 4, 0, x0, %1, %2" :: "i"(RISCV_CUSTOM0), "r"(barried_id), "r"(num_warps));
 }
 
-// Mod 0 
+// Matrices load
 inline void vx_mload(int* input, int* weights) {
     // Load input and weights matrices
     //             .insn r opcode6, func3, func7, rd, rs1, rs2

--- a/kernel/include/vx_intrinsics.h
+++ b/kernel/include/vx_intrinsics.h
@@ -154,7 +154,7 @@ inline void vx_barrier(unsigned barried_id, unsigned num_warps) {
 }
 
 // Mod 0 
-inline void vx_mload(int input[32], int weights[32]) {
+inline void vx_mload(int32_t* input, int32_t* weights) {
     // Load input and weights matrices
     //             .insn r opcode6, func3, func7, rd, rs1, rs2
     asm volatile (".insn r %0, 0, 0, 1, %1, %2" :: "i"(RISCV_CUSTOM2), "r"(input), "r"(weights));

--- a/sim/rtlsim/Makefile
+++ b/sim/rtlsim/Makefile
@@ -74,6 +74,8 @@ VL_FLAGS += -j $(THREADS)
 ifdef DEBUG
 	VL_FLAGS += --trace --trace-structs $(DBG_FLAGS)
 	CXXFLAGS += -g -O0 $(DBG_FLAGS)
+    # Faster compilation times
+    VL_FLAGS += --hierarchical
 else    
 	VL_FLAGS += -DNDEBUG
 	CXXFLAGS += -O2 -DNDEBUG

--- a/tests/regression/Makefile
+++ b/tests/regression/Makefile
@@ -8,6 +8,7 @@ all:
 	$(MAKE) -C diverge
 	$(MAKE) -C sort
 	$(MAKE) -C fence
+	$(MAKE) -C tmul
 	$(MAKE) -C no_mf_ext
 	$(MAKE) -C no_smem
 	$(MAKE) -C vecaddx
@@ -23,6 +24,7 @@ run-simx:
 	$(MAKE) -C diverge run-simx
 	$(MAKE) -C sort run-simx
 	$(MAKE) -C fence run-simx
+	$(MAKE) -C tmul run-simx
 	$(MAKE) -C no_mf_ext run-simx
 	$(MAKE) -C no_smem run-simx
 	$(MAKE) -C vecaddx run-simx
@@ -38,6 +40,7 @@ run-rtlsim:
 	$(MAKE) -C diverge run-rtlsim
 	$(MAKE) -C sort run-rtlsim
 	$(MAKE) -C fence run-rtlsim
+	$(MAKE) -C tmul run-rtlsim
 	$(MAKE) -C no_mf_ext run-rtlsim
 	$(MAKE) -C no_smem run-rtlsim
 	$(MAKE) -C vecaddx run-rtlsim
@@ -53,6 +56,7 @@ run-opae:
 	$(MAKE) -C diverge run-opae
 	$(MAKE) -C sort run-opae
 	$(MAKE) -C fence run-opae
+	$(MAKE) -C tmul run-opae
 	$(MAKE) -C no_mf_ext run-opae
 	$(MAKE) -C no_smem run-opae
 	$(MAKE) -C vecaddx run-opae
@@ -68,6 +72,7 @@ clean:
 	$(MAKE) -C diverge clean
 	$(MAKE) -C sort clean
 	$(MAKE) -C fence clean
+	$(MAKE) -C tmul clean
 	$(MAKE) -C no_mf_ext clean
 	$(MAKE) -C no_smem clean
 	$(MAKE) -C vecaddx clean
@@ -83,6 +88,7 @@ clean-all:
 	$(MAKE) -C diverge clean-all
 	$(MAKE) -C sort clean-all
 	$(MAKE) -C fence clean-all
+	$(MAKE) -C tmul clean-all
 	$(MAKE) -C no_mf_ext clean-all
 	$(MAKE) -C no_smem clean-all
 	$(MAKE) -C vecaddx clean-all

--- a/tests/regression/tmul/common.h
+++ b/tests/regression/tmul/common.h
@@ -1,0 +1,14 @@
+#ifndef _COMMON_H_
+#define _COMMON_H_
+
+#define KERNEL_ARG_DEV_MEM_ADDR 0x7ffff000
+
+typedef struct {
+  uint32_t num_tasks;
+  uint32_t task_size;
+  uint64_t src0_addr;
+  uint64_t src1_addr;
+  uint64_t dst_addr;
+} kernel_arg_t;
+
+#endif

--- a/tests/regression/tmul/common.h
+++ b/tests/regression/tmul/common.h
@@ -3,12 +3,16 @@
 
 #define KERNEL_ARG_DEV_MEM_ADDR 0x7ffff000
 
+#ifndef TYPE
+#define TYPE int
+#endif
+
 typedef struct {
   uint32_t num_tasks;
-  uint32_t task_size;
-  uint64_t src0_addr;
-  uint64_t src1_addr;
-  uint64_t dst_addr;
+  uint32_t size;
+  uint32_t A_addr;
+  uint32_t B_addr;
+  uint32_t C_addr;
 } kernel_arg_t;
 
 #endif

--- a/tests/regression/tmul/common.h
+++ b/tests/regression/tmul/common.h
@@ -10,9 +10,9 @@
 typedef struct {
   uint32_t num_tasks;
   uint32_t size;
-  uint32_t A_addr;
-  uint32_t B_addr;
-  uint32_t C_addr;
+  uint64_t A_addr;
+  uint64_t B_addr;
+  uint64_t C_addr;
 } kernel_arg_t;
 
 #endif

--- a/tests/regression/tmul/kernel.cpp
+++ b/tests/regression/tmul/kernel.cpp
@@ -1,6 +1,5 @@
 #include <stdint.h>
 #include "vx_intrinsics.h"
-#include "vx_print.h"
 #include "vx_spawn.h"
 #include "common.h"
 
@@ -8,7 +7,6 @@ void kernel_body(int task_id, kernel_arg_t* __UNIFORM__ arg) {
 	TYPE* A = reinterpret_cast<TYPE*>(arg->A_addr);
 	TYPE* B = reinterpret_cast<TYPE*>(arg->B_addr);
 	
-	vx_printf("%p\t%p\n",A, B);
 	vx_mload(A, B);
 	vx_fence();
 }

--- a/tests/regression/tmul/kernel.cpp
+++ b/tests/regression/tmul/kernel.cpp
@@ -1,16 +1,12 @@
 #include <stdint.h>
-#include <vx_intrinsics.h>
-#include <vx_spawn.h>
+#include "vx_intrinsics.h"
+#include "vx_spawn.h"
 #include "common.h"
 
 void kernel_body(int task_id, kernel_arg_t* __UNIFORM__ arg) {
 	auto A = reinterpret_cast<TYPE*>(arg->A_addr);
 	auto B = reinterpret_cast<TYPE*>(arg->B_addr);
-	// auto C = reinterpret_cast<TYPE*>(arg->C_addr);
-    auto size  = arg->size;
-
 	vx_mload(A, B);
-	vx_fence();
 }
 
 int main() {

--- a/tests/regression/tmul/kernel.cpp
+++ b/tests/regression/tmul/kernel.cpp
@@ -1,0 +1,25 @@
+#include <stdint.h>
+#include <vx_intrinsics.h>
+#include <vx_spawn.h>
+#include "common.h"
+
+void kernel_body(int task_id, kernel_arg_t* __UNIFORM__ arg) {
+	uint32_t count    = arg->task_size;
+	int32_t* src0_ptr = (int32_t*)arg->src0_addr;
+	int32_t* src1_ptr = (int32_t*)arg->src1_addr;
+	// int32_t* dst_ptr  = (int32_t*)arg->dst_addr;
+
+	uint32_t offset = task_id * count;
+	for (uint32_t i = 0; i < count; ++i) {
+		// dst_ptr[offset+i] = src0_ptr[offset+i] + src1_ptr[offset+i];
+		vx_mload(src0_ptr + offset + i, src1_ptr + offset + i);//, dst_ptr + offset + i);
+	}
+
+	vx_fence();
+}
+
+int main() {
+	kernel_arg_t* arg = (kernel_arg_t*)KERNEL_ARG_DEV_MEM_ADDR;
+	vx_spawn_tasks(arg->num_tasks, (vx_spawn_tasks_cb)kernel_body, arg);
+	return 0;
+}

--- a/tests/regression/tmul/kernel.cpp
+++ b/tests/regression/tmul/kernel.cpp
@@ -1,12 +1,16 @@
 #include <stdint.h>
 #include "vx_intrinsics.h"
+#include "vx_print.h"
 #include "vx_spawn.h"
 #include "common.h"
 
 void kernel_body(int task_id, kernel_arg_t* __UNIFORM__ arg) {
-	auto A = reinterpret_cast<TYPE*>(arg->A_addr);
-	auto B = reinterpret_cast<TYPE*>(arg->B_addr);
+	TYPE* A = reinterpret_cast<TYPE*>(arg->A_addr);
+	TYPE* B = reinterpret_cast<TYPE*>(arg->B_addr);
+	
+	vx_printf("%p\t%p\n",A, B);
 	vx_mload(A, B);
+	vx_fence();
 }
 
 int main() {

--- a/tests/regression/tmul/kernel.cpp
+++ b/tests/regression/tmul/kernel.cpp
@@ -4,17 +4,12 @@
 #include "common.h"
 
 void kernel_body(int task_id, kernel_arg_t* __UNIFORM__ arg) {
-	uint32_t count    = arg->task_size;
-	int32_t* src0_ptr = (int32_t*)arg->src0_addr;
-	int32_t* src1_ptr = (int32_t*)arg->src1_addr;
-	// int32_t* dst_ptr  = (int32_t*)arg->dst_addr;
+	auto A = reinterpret_cast<TYPE*>(arg->A_addr);
+	auto B = reinterpret_cast<TYPE*>(arg->B_addr);
+	// auto C = reinterpret_cast<TYPE*>(arg->C_addr);
+    auto size  = arg->size;
 
-	uint32_t offset = task_id * count;
-	for (uint32_t i = 0; i < count; ++i) {
-		// dst_ptr[offset+i] = src0_ptr[offset+i] + src1_ptr[offset+i];
-		vx_mload(src0_ptr + offset + i, src1_ptr + offset + i);//, dst_ptr + offset + i);
-	}
-
+	vx_mload(A, B);
 	vx_fence();
 }
 

--- a/tests/regression/tmul/main.cpp
+++ b/tests/regression/tmul/main.cpp
@@ -1,0 +1,194 @@
+#include <iostream>
+#include <unistd.h>
+#include <string.h>
+#include <vector>
+#include <vortex.h>
+#include "common.h"
+
+#define RT_CHECK(_expr)                                         \
+   do {                                                         \
+     int _ret = _expr;                                          \
+     if (0 == _ret)                                             \
+       break;                                                   \
+     printf("Error: '%s' returned %d!\n", #_expr, (int)_ret);   \
+	 cleanup();			                                              \
+     exit(-1);                                                  \
+   } while (false)
+
+///////////////////////////////////////////////////////////////////////////////
+
+const char* kernel_file = "kernel.bin";
+uint32_t count = 0;
+
+vx_device_h device = nullptr;
+std::vector<uint8_t> staging_buf;
+kernel_arg_t kernel_arg = {};
+
+static void show_usage() {
+   std::cout << "Vortex Test." << std::endl;
+   std::cout << "Usage: [-k: kernel] [-n words] [-h: help]" << std::endl;
+}
+
+static void parse_args(int argc, char **argv) {
+  int c;
+  while ((c = getopt(argc, argv, "n:k:h?")) != -1) {
+    switch (c) {
+    case 'n':
+      count = atoi(optarg);
+      break;
+    case 'k':
+      kernel_file = optarg;
+      break;
+    case 'h':
+    case '?': {
+      show_usage();
+      exit(0);
+    } break;
+    default:
+      show_usage();
+      exit(-1);
+    }
+  }
+}
+
+void cleanup() {
+  if (device) {
+    vx_mem_free(device, kernel_arg.src0_addr);
+    vx_mem_free(device, kernel_arg.src1_addr);
+    vx_mem_free(device, kernel_arg.dst_addr);
+    vx_dev_close(device);
+  }
+}
+
+int run_test(const kernel_arg_t& kernel_arg,
+             uint32_t buf_size, 
+             uint32_t num_points) {
+  // start device
+  std::cout << "start device" << std::endl;
+  RT_CHECK(vx_start(device));
+
+  // wait for completion
+  std::cout << "wait for completion" << std::endl;
+  RT_CHECK(vx_ready_wait(device, VX_MAX_TIMEOUT));
+
+  // download destination buffer
+  std::cout << "download destination buffer" << std::endl;
+  RT_CHECK(vx_copy_from_dev(device, staging_buf.data(), kernel_arg.dst_addr, buf_size));
+
+  // verify result
+  std::cout << "verify result" << std::endl;  
+  {
+    int errors = 0;
+    auto buf_ptr = (int32_t*)staging_buf.data();
+    for (uint32_t i = 0; i < num_points; ++i) {
+      int ref = i + i; 
+      int cur = buf_ptr[i];
+      if (cur != ref) {
+        std::cout << "error at result #" << std::dec << i
+                  << std::hex << ": actual 0x" << cur << ", expected 0x" << ref << std::endl;
+        ++errors;
+      }
+    }
+    if (errors != 0) {
+      std::cout << "Found " << std::dec << errors << " errors!" << std::endl;
+      std::cout << "FAILED!" << std::endl;
+      return 1;  
+    }
+  }
+
+  return 0;
+}
+
+int main(int argc, char *argv[]) {  
+  // parse command arguments
+  parse_args(argc, argv);
+
+  if (count == 0) {
+    count = 1;
+  }
+
+  // open device connection
+  std::cout << "open device connection" << std::endl;  
+  RT_CHECK(vx_dev_open(&device));
+
+  uint64_t num_cores, num_warps, num_threads;
+  RT_CHECK(vx_dev_caps(device, VX_CAPS_NUM_CORES, &num_cores));
+  RT_CHECK(vx_dev_caps(device, VX_CAPS_NUM_WARPS, &num_warps));
+  RT_CHECK(vx_dev_caps(device, VX_CAPS_NUM_THREADS, &num_threads));
+
+  uint32_t num_tasks  = num_cores * num_warps * num_threads;
+  uint32_t num_points = count * num_tasks;
+  uint32_t buf_size   = num_points * sizeof(int32_t);
+
+  std::cout << "number of points: " << num_points << std::endl;
+  std::cout << "buffer size: " << buf_size << " bytes" << std::endl;
+
+  // upload program
+  std::cout << "upload program" << std::endl;  
+  RT_CHECK(vx_upload_kernel_file(device, kernel_file));
+
+  // allocate device memory
+  std::cout << "allocate device memory" << std::endl;
+  RT_CHECK(vx_mem_alloc(device, buf_size, VX_MEM_TYPE_GLOBAL, &kernel_arg.src0_addr));
+  RT_CHECK(vx_mem_alloc(device, buf_size, VX_MEM_TYPE_GLOBAL, &kernel_arg.src1_addr));
+  RT_CHECK(vx_mem_alloc(device, buf_size, VX_MEM_TYPE_GLOBAL, &kernel_arg.dst_addr));
+
+  kernel_arg.num_tasks = num_tasks;
+  kernel_arg.task_size = count;
+
+  std::cout << "dev_src0=0x" << std::hex << kernel_arg.src0_addr << std::endl;
+  std::cout << "dev_src1=0x" << std::hex << kernel_arg.src1_addr << std::endl;
+  std::cout << "dev_dst=0x" << std::hex << kernel_arg.dst_addr << std::endl;
+  
+  // allocate staging buffer  
+  std::cout << "allocate staging buffer" << std::endl;    
+  uint32_t alloc_size = std::max<uint32_t>(buf_size, sizeof(kernel_arg_t));
+  staging_buf.resize(alloc_size);
+  
+  // upload kernel argument
+  std::cout << "upload kernel argument" << std::endl;
+  memcpy(staging_buf.data(), &kernel_arg, sizeof(kernel_arg_t));
+  RT_CHECK(vx_copy_to_dev(device, KERNEL_ARG_DEV_MEM_ADDR, staging_buf.data(), sizeof(kernel_arg_t)));
+
+  // upload source buffer0
+  {
+    std::cout << "upload source buffer0" << std::endl;
+    auto buf_ptr = (int32_t*)staging_buf.data();
+    for (uint32_t i = 0; i < num_points; ++i) {
+      buf_ptr[i] = i-1;
+    }  
+    RT_CHECK(vx_copy_to_dev(device, kernel_arg.src0_addr, staging_buf.data(), buf_size));
+  }
+
+  // upload source buffer1
+  {
+    std::cout << "upload source buffer1" << std::endl;
+    auto buf_ptr = (int32_t*)staging_buf.data();
+    for (uint32_t i = 0; i < num_points; ++i) {
+      buf_ptr[i] = i+1;
+    }  
+    RT_CHECK(vx_copy_to_dev(device, kernel_arg.src1_addr, staging_buf.data(), buf_size));
+  }
+
+  // clear destination buffer
+  {
+    std::cout << "clear destination buffer" << std::endl;      
+    auto buf_ptr = (int32_t*)staging_buf.data();
+    for (uint32_t i = 0; i < num_points; ++i) {
+      buf_ptr[i] = 0xdeadbeef;
+    }  
+    RT_CHECK(vx_copy_to_dev(device, kernel_arg.dst_addr, staging_buf.data(), buf_size));  
+  }
+
+  // run tests
+  std::cout << "run tests" << std::endl;
+  RT_CHECK(run_test(kernel_arg, buf_size, num_points));
+
+  // cleanup
+  std::cout << "cleanup" << std::endl;  
+  cleanup();
+
+  std::cout << "PASSED!" << std::endl;
+
+  return 0;
+}

--- a/tests/regression/tmul/main.cpp
+++ b/tests/regression/tmul/main.cpp
@@ -175,8 +175,8 @@ int main(int argc, char *argv[]) {
   std::vector<TYPE> refs(num_points);
   for (uint32_t i = 0; i < size; ++i) {
     for (uint32_t j = 0; j < size; ++j) {
-      src_A[i] = static_cast<TYPE>(i == j);
-      src_B[i] = static_cast<TYPE>(i == j);
+      src_A[i * size + j] = static_cast<TYPE>(i == j);
+      src_B[i * size + j] = static_cast<TYPE>(i == j);
     }
   }
 

--- a/tests/regression/tmul/main.cpp
+++ b/tests/regression/tmul/main.cpp
@@ -2,8 +2,11 @@
 #include <unistd.h>
 #include <string.h>
 #include <vector>
+#include <chrono>
 #include <vortex.h>
 #include "common.h"
+
+#define FLOAT_ULP 6
 
 #define RT_CHECK(_expr)                                         \
    do {                                                         \
@@ -17,8 +20,68 @@
 
 ///////////////////////////////////////////////////////////////////////////////
 
+template <typename Type>
+class Comparator {};
+
+template <>
+class Comparator<int> {
+public:
+  static const char* type_str() {
+    return "integer";
+  }
+  static int generate() {
+    return rand();
+  }
+  static bool compare(int a, int b, int index, int errors) {
+    if (a != b) {
+      if (errors < 100) {
+        printf("*** error: [%d] expected=%d, actual=%d\n", index, a, b);
+      }
+      return false;
+    }
+    return true;
+  }
+};
+
+template <>
+class Comparator<float> {
+public:
+  static const char* type_str() {
+    return "float";
+  }
+  static int generate() {
+    return static_cast<float>(rand()) / RAND_MAX;
+  }
+  static bool compare(float a, float b, int index, int errors) {
+    union fi_t { float f; int32_t i; };
+    fi_t fa, fb;
+    fa.f = a;
+    fb.f = b;
+    auto d = std::abs(fa.i - fb.i);
+    if (d > FLOAT_ULP) {
+      if (errors < 100) {
+        printf("*** error: [%d] expected=%f, actual=%f\n", index, a, b);
+      }
+      return false;
+    }
+    return true;
+  }
+};
+
+static void matmul_cpu(TYPE* out, const TYPE* A, const TYPE* B, uint32_t width, uint32_t height) {
+  for (uint32_t row = 0; row < height; ++row) {
+    for (uint32_t col = 0; col < width; ++col) {
+      TYPE sum(0);
+      for (uint32_t e = 0; e < width; ++e) {
+          sum += A[row * width + e] * B[e * width + col];
+      }
+      out[row * width + col] = sum;
+    }
+  }
+}
+
 const char* kernel_file = "kernel.bin";
-uint32_t count = 0;
+uint32_t size = 32;
 
 vx_device_h device = nullptr;
 std::vector<uint8_t> staging_buf;
@@ -26,7 +89,7 @@ kernel_arg_t kernel_arg = {};
 
 static void show_usage() {
    std::cout << "Vortex Test." << std::endl;
-   std::cout << "Usage: [-k: kernel] [-n words] [-h: help]" << std::endl;
+   std::cout << "Usage: [-k: kernel] [-n size] [-h: help]" << std::endl;
 }
 
 static void parse_args(int argc, char **argv) {
@@ -34,7 +97,7 @@ static void parse_args(int argc, char **argv) {
   while ((c = getopt(argc, argv, "n:k:h?")) != -1) {
     switch (c) {
     case 'n':
-      count = atoi(optarg);
+      size = atoi(optarg);
       break;
     case 'k':
       kernel_file = optarg;
@@ -53,16 +116,95 @@ static void parse_args(int argc, char **argv) {
 
 void cleanup() {
   if (device) {
-    vx_mem_free(device, kernel_arg.src0_addr);
-    vx_mem_free(device, kernel_arg.src1_addr);
-    vx_mem_free(device, kernel_arg.dst_addr);
+    vx_mem_free(device, kernel_arg.A_addr);
+    vx_mem_free(device, kernel_arg.B_addr);
+    vx_mem_free(device, kernel_arg.C_addr);
     vx_dev_close(device);
   }
 }
 
-int run_test(const kernel_arg_t& kernel_arg,
-             uint32_t buf_size, 
-             uint32_t num_points) {
+int main(int argc, char *argv[]) {
+  // parse command arguments
+  parse_args(argc, argv);
+
+  std::srand(50);
+
+  // open device connection
+  std::cout << "open device connection" << std::endl;
+  RT_CHECK(vx_dev_open(&device));
+
+  uint32_t num_points = size * size;
+  uint32_t buf_size = num_points * sizeof(TYPE);
+
+  std::cout << "data type: " << Comparator<TYPE>::type_str() << std::endl;
+  std::cout << "matrix size: " << size << "x" << size << std::endl;
+  std::cout << "buffer size: " << buf_size << " bytes" << std::endl;
+
+  // upload program
+  std::cout << "upload program" << std::endl;
+  RT_CHECK(vx_upload_kernel_file(device, kernel_file));
+
+  // allocate device memory
+  std::cout << "allocate device memory" << std::endl;
+  RT_CHECK(vx_mem_alloc(device, buf_size, VX_MEM_TYPE_GLOBAL, &kernel_arg.A_addr));
+  RT_CHECK(vx_mem_alloc(device, buf_size, VX_MEM_TYPE_GLOBAL, &kernel_arg.B_addr));
+  // RT_CHECK(vx_mem_alloc(device, buf_size, VX_MEM_TYPE_GLOBAL, &kernel_arg.C_addr));
+
+  kernel_arg.num_tasks = num_points;
+  kernel_arg.size = size;
+
+  std::cout << "dev_src0=0x" << std::hex << kernel_arg.A_addr << std::endl;
+  std::cout << "dev_src1=0x" << std::hex << kernel_arg.B_addr << std::endl;
+  // std::cout << "dev_dst=0x" << std::hex << kernel_arg.C_addr << std::endl;
+
+  // allocate staging buffer
+  std::cout << "allocate staging buffer" << std::endl;
+  uint32_t alloc_size = std::max<uint32_t>(buf_size, sizeof(kernel_arg_t));
+  staging_buf.resize(alloc_size);
+
+  // upload kernel argument
+  std::cout << "upload kernel argument" << std::endl;
+  memcpy(staging_buf.data(), &kernel_arg, sizeof(kernel_arg_t));
+  RT_CHECK(vx_copy_to_dev(device, KERNEL_ARG_DEV_MEM_ADDR, staging_buf.data(), sizeof(kernel_arg_t)));
+
+  // generate source data
+  std::vector<TYPE> src_A(num_points);
+  std::vector<TYPE> src_B(num_points);
+  std::vector<TYPE> refs(num_points);
+  for (uint32_t i = 0; i < size; ++i) {
+    for (uint32_t j = 0; j < size; ++j) {
+      src_A[i] = static_cast<TYPE>(i == j);
+      src_B[i] = static_cast<TYPE>(i == j);
+    }
+  }
+
+  // upload source buffer0
+  {
+    std::cout << "upload source buffer0" << std::endl;
+    auto buf_ptr = (TYPE*)staging_buf.data();
+    for (uint32_t i = 0; i < num_points; ++i) {
+      buf_ptr[i] = src_A[i];
+    }
+    RT_CHECK(vx_copy_to_dev(device, kernel_arg.A_addr, staging_buf.data(), buf_size));
+  }
+
+  // upload source buffer1
+  {
+    std::cout << "upload source buffer1" << std::endl;
+    auto buf_ptr = (TYPE*)staging_buf.data();
+    for (uint32_t i = 0; i < num_points; ++i) {
+      buf_ptr[i] = src_B[i];
+    }
+    RT_CHECK(vx_copy_to_dev(device, kernel_arg.B_addr, staging_buf.data(), buf_size));
+  }
+
+  // clear destination buffer
+  // std::cout << "clear destination buffer" << std::endl;
+  // memset(staging_buf.data(), 0, num_points * sizeof(TYPE));
+  // RT_CHECK(vx_copy_to_dev(device, kernel_arg.C_addr, staging_buf.data(), buf_size));
+
+  auto time_start = std::chrono::high_resolution_clock::now();
+
   // start device
   std::cout << "start device" << std::endl;
   RT_CHECK(vx_start(device));
@@ -71,121 +213,35 @@ int run_test(const kernel_arg_t& kernel_arg,
   std::cout << "wait for completion" << std::endl;
   RT_CHECK(vx_ready_wait(device, VX_MAX_TIMEOUT));
 
+  auto time_end = std::chrono::high_resolution_clock::now();
+  double elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(time_end - time_start).count();
+  printf("Elapsed time: %lg ms\n", elapsed);
+
   // download destination buffer
   std::cout << "download destination buffer" << std::endl;
-  RT_CHECK(vx_copy_from_dev(device, staging_buf.data(), kernel_arg.dst_addr, buf_size));
+  RT_CHECK(vx_copy_from_dev(device, staging_buf.data(), kernel_arg.C_addr, buf_size));
 
   // verify result
-  std::cout << "verify result" << std::endl;  
+  std::cout << "verify result" << std::endl;
   {
     int errors = 0;
-    auto buf_ptr = (int32_t*)staging_buf.data();
-    for (uint32_t i = 0; i < num_points; ++i) {
-      int ref = i + i; 
-      int cur = buf_ptr[i];
-      if (cur != ref) {
-        std::cout << "error at result #" << std::dec << i
-                  << std::hex << ": actual 0x" << cur << ", expected 0x" << ref << std::endl;
+    auto buf_ptr = (TYPE*)staging_buf.data();
+    for (uint32_t i = 0; i < refs.size(); ++i) {
+      auto ref = refs[i];
+      auto cur = buf_ptr[i];
+      if (!Comparator<TYPE>::compare(cur, ref, i, errors)) {
         ++errors;
       }
     }
     if (errors != 0) {
       std::cout << "Found " << std::dec << errors << " errors!" << std::endl;
       std::cout << "FAILED!" << std::endl;
-      return 1;  
+      return 1;
     }
   }
 
-  return 0;
-}
-
-int main(int argc, char *argv[]) {  
-  // parse command arguments
-  parse_args(argc, argv);
-
-  if (count == 0) {
-    count = 1;
-  }
-
-  // open device connection
-  std::cout << "open device connection" << std::endl;  
-  RT_CHECK(vx_dev_open(&device));
-
-  uint64_t num_cores, num_warps, num_threads;
-  RT_CHECK(vx_dev_caps(device, VX_CAPS_NUM_CORES, &num_cores));
-  RT_CHECK(vx_dev_caps(device, VX_CAPS_NUM_WARPS, &num_warps));
-  RT_CHECK(vx_dev_caps(device, VX_CAPS_NUM_THREADS, &num_threads));
-
-  uint32_t num_tasks  = num_cores * num_warps * num_threads;
-  uint32_t num_points = count * num_tasks;
-  uint32_t buf_size   = num_points * sizeof(int32_t);
-
-  std::cout << "number of points: " << num_points << std::endl;
-  std::cout << "buffer size: " << buf_size << " bytes" << std::endl;
-
-  // upload program
-  std::cout << "upload program" << std::endl;  
-  RT_CHECK(vx_upload_kernel_file(device, kernel_file));
-
-  // allocate device memory
-  std::cout << "allocate device memory" << std::endl;
-  RT_CHECK(vx_mem_alloc(device, buf_size, VX_MEM_TYPE_GLOBAL, &kernel_arg.src0_addr));
-  RT_CHECK(vx_mem_alloc(device, buf_size, VX_MEM_TYPE_GLOBAL, &kernel_arg.src1_addr));
-  RT_CHECK(vx_mem_alloc(device, buf_size, VX_MEM_TYPE_GLOBAL, &kernel_arg.dst_addr));
-
-  kernel_arg.num_tasks = num_tasks;
-  kernel_arg.task_size = count;
-
-  std::cout << "dev_src0=0x" << std::hex << kernel_arg.src0_addr << std::endl;
-  std::cout << "dev_src1=0x" << std::hex << kernel_arg.src1_addr << std::endl;
-  std::cout << "dev_dst=0x" << std::hex << kernel_arg.dst_addr << std::endl;
-  
-  // allocate staging buffer  
-  std::cout << "allocate staging buffer" << std::endl;    
-  uint32_t alloc_size = std::max<uint32_t>(buf_size, sizeof(kernel_arg_t));
-  staging_buf.resize(alloc_size);
-  
-  // upload kernel argument
-  std::cout << "upload kernel argument" << std::endl;
-  memcpy(staging_buf.data(), &kernel_arg, sizeof(kernel_arg_t));
-  RT_CHECK(vx_copy_to_dev(device, KERNEL_ARG_DEV_MEM_ADDR, staging_buf.data(), sizeof(kernel_arg_t)));
-
-  // upload source buffer0
-  {
-    std::cout << "upload source buffer0" << std::endl;
-    auto buf_ptr = (int32_t*)staging_buf.data();
-    for (uint32_t i = 0; i < num_points; ++i) {
-      buf_ptr[i] = i-1;
-    }  
-    RT_CHECK(vx_copy_to_dev(device, kernel_arg.src0_addr, staging_buf.data(), buf_size));
-  }
-
-  // upload source buffer1
-  {
-    std::cout << "upload source buffer1" << std::endl;
-    auto buf_ptr = (int32_t*)staging_buf.data();
-    for (uint32_t i = 0; i < num_points; ++i) {
-      buf_ptr[i] = i+1;
-    }  
-    RT_CHECK(vx_copy_to_dev(device, kernel_arg.src1_addr, staging_buf.data(), buf_size));
-  }
-
-  // clear destination buffer
-  {
-    std::cout << "clear destination buffer" << std::endl;      
-    auto buf_ptr = (int32_t*)staging_buf.data();
-    for (uint32_t i = 0; i < num_points; ++i) {
-      buf_ptr[i] = 0xdeadbeef;
-    }  
-    RT_CHECK(vx_copy_to_dev(device, kernel_arg.dst_addr, staging_buf.data(), buf_size));  
-  }
-
-  // run tests
-  std::cout << "run tests" << std::endl;
-  RT_CHECK(run_test(kernel_arg, buf_size, num_points));
-
   // cleanup
-  std::cout << "cleanup" << std::endl;  
+  std::cout << "cleanup" << std::endl;
   cleanup();
 
   std::cout << "PASSED!" << std::endl;

--- a/tests/regression/tmul/main.cpp
+++ b/tests/regression/tmul/main.cpp
@@ -83,7 +83,7 @@ static void matmul_cpu(TYPE* out, const TYPE* A, const TYPE* B, uint32_t width, 
 */
 
 const char* kernel_file = "kernel.bin";
-uint32_t size = 32;
+uint32_t size = 2;
 
 vx_device_h device = nullptr;
 std::vector<uint8_t> staging_buf;
@@ -120,7 +120,7 @@ void cleanup() {
   if (device) {
     vx_mem_free(device, kernel_arg.A_addr);
     vx_mem_free(device, kernel_arg.B_addr);
-    vx_mem_free(device, kernel_arg.C_addr);
+   //  vx_mem_free(device, kernel_arg.C_addr);
     vx_dev_close(device);
   }
 }
@@ -220,10 +220,13 @@ int main(int argc, char *argv[]) {
   printf("Elapsed time: %lg ms\n", elapsed);
 
   // download destination buffer
+  /*
   std::cout << "download destination buffer" << std::endl;
   RT_CHECK(vx_copy_from_dev(device, staging_buf.data(), kernel_arg.C_addr, buf_size));
+  */
 
   // verify result
+  /*
   std::cout << "verify result" << std::endl;
   {
     int errors = 0;
@@ -241,6 +244,7 @@ int main(int argc, char *argv[]) {
       return 1;
     }
   }
+  */
 
   // cleanup
   std::cout << "cleanup" << std::endl;

--- a/tests/regression/tmul/main.cpp
+++ b/tests/regression/tmul/main.cpp
@@ -68,6 +68,7 @@ public:
   }
 };
 
+/*
 static void matmul_cpu(TYPE* out, const TYPE* A, const TYPE* B, uint32_t width, uint32_t height) {
   for (uint32_t row = 0; row < height; ++row) {
     for (uint32_t col = 0; col < width; ++col) {
@@ -79,6 +80,7 @@ static void matmul_cpu(TYPE* out, const TYPE* A, const TYPE* B, uint32_t width, 
     }
   }
 }
+*/
 
 const char* kernel_file = "kernel.bin";
 uint32_t size = 32;

--- a/tests/regression/tmul/main.cpp
+++ b/tests/regression/tmul/main.cpp
@@ -219,33 +219,6 @@ int main(int argc, char *argv[]) {
   double elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(time_end - time_start).count();
   printf("Elapsed time: %lg ms\n", elapsed);
 
-  // download destination buffer
-  /*
-  std::cout << "download destination buffer" << std::endl;
-  RT_CHECK(vx_copy_from_dev(device, staging_buf.data(), kernel_arg.C_addr, buf_size));
-  */
-
-  // verify result
-  /*
-  std::cout << "verify result" << std::endl;
-  {
-    int errors = 0;
-    auto buf_ptr = (TYPE*)staging_buf.data();
-    for (uint32_t i = 0; i < refs.size(); ++i) {
-      auto ref = refs[i];
-      auto cur = buf_ptr[i];
-      if (!Comparator<TYPE>::compare(cur, ref, i, errors)) {
-        ++errors;
-      }
-    }
-    if (errors != 0) {
-      std::cout << "Found " << std::dec << errors << " errors!" << std::endl;
-      std::cout << "FAILED!" << std::endl;
-      return 1;
-    }
-  }
-  */
-
   // cleanup
   std::cout << "cleanup" << std::endl;
   cleanup();


### PR DESCRIPTION
Implement load of two $2\times 2$ matrices 🎉 .

Relevant changes are:
- New `vx_mload` intrinsic. It inserts a new custom R-type RISCV instruction with two addresses as input (inside registers), one for each matrix to load.
  - This new instruction is at warp level. Each thread loads the two rows that it will need to compute one of the output values of the matrix multiplication (for instance, thread 0 loads the first row of the first matrix and the first column of the second matrix).
- New `INST_LSU_MLOAD` macro with value `4b'1110` for the `op_type` of the new instruction. The combination of `op_type=INST_LSU_MLOAD` and `ex_type=01` is unique, which allows to uniquely identify the new instruction added.
- Modified `VX_lsu_unit.sv` so that when an `INST_LSU_MLOAD` arrives, 3 additional "instructions" are spawned in the pipeline so that the threads do their corresponding four memory requests and the pipeline is stalled until the requests are made.
- Modified the commit procedure by only decreasing the count of scheduled instructions when the last of the new instructions generated is committed. This solves the problem that one mload instruction is scheduled at the beginning but 4 of them are committed afterwards.

