### PR TITLE
Add virtual memory allocator for vortex vm

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -100,3 +100,19 @@ jobs:
       script:
         - ./ci/travis_run.py ./ci/regression.sh --debug
         - ./ci/travis_run.py ./ci/regression.sh --stress
+
+    - stage: test
+      name: virtual_memory
+      env: XLEN=32 
+      env: VM_DISABLE=1
+      script:
+        - ./ci/travis_run.py ./ci/regression.sh --regression
+        - ./ci/travis_run.py ./ci/regression.sh --opencl
+    
+    - stage: test
+      name: virtual_memory
+      env: XLEN=64
+      env: VM_DISABLE=1
+      script:
+        - ./ci/travis_run.py ./ci/regression.sh --regression
+        - ./ci/travis_run.py ./ci/regression.sh --opencl

--- a/ci/regression.sh.in
+++ b/ci/regression.sh.in
@@ -19,6 +19,8 @@ set -e
 # clear blackbox cache
 rm -f blackbox.*.cache
 
+# HW: add a test "VM Test" to make sure VM feature is enabled
+
 XLEN=${XLEN:=@XLEN@}
 
 echo "Vortex Regression Test: XLEN=$XLEN"

--- a/runtime/include/vortex.h
+++ b/runtime/include/vortex.h
@@ -61,6 +61,7 @@ typedef void* vx_buffer_h;
 #define VX_MEM_READ                 0x1
 #define VX_MEM_WRITE                0x2
 #define VX_MEM_READ_WRITE           0x3
+#define VX_MEM_PIN_MEMORY           0x4
 
 // open the device and connect to it
 int vx_dev_open(vx_device_h* hdevice);

--- a/runtime/simx/vortex.cpp
+++ b/runtime/simx/vortex.cpp
@@ -199,6 +199,7 @@ public:
     uint64_t addr = 0;
 
     DBGPRINT("[RT:mem_alloc] size: 0x%lx, asize, 0x%lx,flag : 0x%d\n", size, asize, flags);
+    // HW: when vm is supported this global_mem_ should be virtual memory allocator
     CHECK_ERR(global_mem_.allocate(asize, &addr), {
       return err;
     });
@@ -231,7 +232,7 @@ public:
   int mem_free(uint64_t dev_addr)
   {
 #ifdef VM_ENABLE
-    uint64_t paddr= page_table_walk(dev_addr);
+    uint64_t paddr = page_table_walk(dev_addr);
     return global_mem_.release(paddr);
 #else
     return global_mem_.release(dev_addr);
@@ -264,6 +265,14 @@ public:
       return -1;
 #ifdef VM_ENABLE
     uint64_t pAddr = page_table_walk(dest_addr);
+    // uint64_t pAddr;
+    // try { 
+    //   pAddr = page_table_walk(dest_addr);
+    // } catch ( Page_Fault_Exception ) {
+    //   // HW: place holder
+    //   // should be virt_to_phy_map here
+    //   phy_to_virt_map(0, dest_addr, 0);
+    // }
     DBGPRINT("  [RT:upload] Upload data to vAddr = 0x%lx (pAddr=0x%lx)\n", dest_addr, pAddr);
     dest_addr = pAddr; //Overwirte
 #endif

--- a/runtime/simx/vortex.cpp
+++ b/runtime/simx/vortex.cpp
@@ -66,6 +66,7 @@ public:
   global_mem_.release(PAGE_TABLE_BASE_ADDR);
   // for (auto i = addr_mapping.begin(); i != addr_mapping.end(); i++) 
   //   page_table_mem_->release(i->second << MEM_PAGE_SIZE);
+  delete virtual_mem_;
   delete page_table_mem_;
 #endif
     if (future_.valid()) {
@@ -114,6 +115,7 @@ public:
   }
 
 #ifdef VM_ENABLE
+
   // virtual (vpn) to phycial (ppn) mapping
   uint64_t map_p2v(uint64_t ppn, uint32_t flags)
   {
@@ -130,6 +132,7 @@ public:
     addr_mapping[ppn] = vpn;
     return vpn;
   }
+
   bool need_trans(uint64_t dev_pAddr)
   {
 
@@ -423,6 +426,7 @@ public:
     virtual_mem_ = new MemoryAllocator(ALLOC_BASE_ADDR >> MEM_PAGE_LOG2_SIZE, (GLOBAL_MEM_SIZE - ALLOC_BASE_ADDR) >> MEM_PAGE_LOG2_SIZE, MEM_PAGE_SIZE, CACHE_BLOCK_SIZE);
     if (virtual_mem_ == nullptr) {
       // virtual_mem_ does not intefere with physical mem, so no need to free space
+      
       return 1;
     }
     

--- a/runtime/simx/vortex.cpp
+++ b/runtime/simx/vortex.cpp
@@ -165,7 +165,7 @@ public:
     }
 
     uint64_t init_pAddr = *dev_pAddr;
-    uint64_t init_vAddr = (map_p2v(init_pAddr >> MEM_PAGE_LOG2_SIZE, flags) << MEM_PAGE_LOG2_SIZE) & ((1 << MEM_PAGE_LOG2_SIZE) - 1);
+    uint64_t init_vAddr = (map_p2v(init_pAddr >> MEM_PAGE_LOG2_SIZE, flags) << MEM_PAGE_LOG2_SIZE) | (init_pAddr & ((1 << MEM_PAGE_LOG2_SIZE) - 1));
     uint64_t ppn = 0, vpn = 0;
 
     // dev_pAddr can be of size greater than a page, but we have to map and update


### PR DESCRIPTION
Added a virtual memory allocator that dynamically allocates virtual addresses instead of generating virtual addresses by adding a fixed offset to their corresponding physical addresses. Tests executed by calling `make -C tests/regression run-simx` pass with no errors.