### PR TITLE
Fixes readme by removing $ from shell commands + small tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-[![Build Status](https://travis-ci.com/vortexgpgpu/vortex.svg?branch=master)](https://travis-ci.com/vortexgpgpu/vortex)
-
 # Vortex GPGPU
 
 Vortex is a full-stack open-source RISC-V GPGPU.
@@ -47,49 +45,63 @@ More detailed build instructions can be found [here](docs/install_vortex.md).
 - [Yosys](https://github.com/YosysHQ/yosys)
 - [Sv2v](https://github.com/zachjs/sv2v)
 ### Install development tools
-    $ sudo apt-get install build-essential
-    $ sudo apt-get install binutils
-    $ sudo apt-get install python
-    $ sudo apt-get install uuid-dev
-    $ sudo apt-get install git
+```sh
+sudo apt-get install build-essential
+sudo apt-get install binutils
+sudo apt-get install python
+sudo apt-get install uuid-dev
+sudo apt-get install git
+```
 ### Install Vortex codebase
-    $ git clone --depth=1 --recursive https://github.com/vortexgpgpu/vortex.git
-    $ cd Vortex
+```sh
+git clone --depth=1 --recursive https://github.com/vortexgpgpu/vortex.git
+cd vortex
+```
 ### Configure your build folder
-    $ mkdir build
-    $ cd build
-    $ ../configure --xlen=32 --tooldir=$HOME/tools
+```sh
+mkdir build
+cd build
+../configure --xlen=32 --tooldir=$HOME/tools
+```
 ### Install prebuilt toolchain
-    $ ./ci/toolchain_install.sh --all
+```sh
+./ci/toolchain_install.sh --all
+```
 ### set environment variables
-    # should always run before using the toolchain!
-    $ source ./ci/toolchain_env.sh
+```sh
+# should always run before using the toolchain!
+source ./ci/toolchain_env.sh
+```
 ### Building Vortex
-    $ make -s
+```sh
+make -s
+```
 ### Quick demo running vecadd OpenCL kernel on 2 cores
-    $ ./ci/blackbox.sh --cores=2 --app=vecadd
+```sh
+./ci/blackbox.sh --cores=2 --app=vecadd
+```
 
 ### Common Developer Tips
 - Installing Vortex kernel and runtime libraries to use with external tools requires passing --prefix=<install-path> to the configure script.
-    ```sh
-    $ ../configure --xlen=32 --tooldir=$HOME/tools --prefix=<install-path>
-    $ make -s
-    $ make install
-    ``````
+```sh
+../configure --xlen=32 --tooldir=$HOME/tools --prefix=<install-path>
+make -s
+make install
+```
 - Building Vortex 64-bit simply requires using --xlen=64 configure option.
-    ```sh
-    $ ../configure --xlen=32 --tooldir=$HOME/tools
-    ```
+```sh
+../configure --xlen=32 --tooldir=$HOME/tools
+```
 - Sourcing "./ci/toolchain_env.sh" is required everytime you start a new terminal. we recommend adding "source <build-path>/ci/toolchain_env.sh" to your ~/.bashrc file to automate the process at login.
-    ```sh
-    $ echo "source <build-path>/ci/toolchain_env.sh" >> ~/.bashrc
-    ```
+```sh
+echo "source <build-path>/ci/toolchain_env.sh" >> ~/.bashrc
+```
 - Making changes to Makefiles in your source tree or adding new folders will require executing the "configure" script again to get it propagated into your build folder.
-    ```sh
-    $ ../configure
-    ```
+```sh
+../configure
+```
 - To debug the GPU, you can generate a "run.log" trace. see /docs/debugging.md for more information.
-    ```sh
-    $ ./ci/blackbox.sh --app=demo --debug=3
-    ```
+```sh
+./ci/blackbox.sh --app=demo --debug=3
+```
 - For additional information, check out the /docs.

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ cd build
 ```sh
 ./ci/toolchain_install.sh --all
 ```
-### set environment variables
+### Set environment variables
 ```sh
 # should always run before using the toolchain!
 source ./ci/toolchain_env.sh


### PR DESCRIPTION
Removed $ from all the shell commands so that they can be easily
1-click copy-pasted from github without the dollar sign, as well
as changed "cd Vortex" to "cd vortex" to match the actual directory
spelling. Also removed obsolete travis ci link as the project
has moved to github ci.