### PR TITLE
Fix invalid use of incomplete type error by including <array>

### DIFF
--- a/runtime/common/common.h
+++ b/runtime/common/common.h
@@ -21,6 +21,7 @@
 
 #include <cstdint>
 #include <unordered_map>
+#include <array>
 
 #define CACHE_BLOCK_SIZE  64
 


### PR DESCRIPTION
Fixes the incomplete type error highlighted in @danikhan632 recent pr by instead putting "#include <array>" in runtime/common/common.h so that it is automatically included in the others.

This fixed the issue for me:
In file included from /home/jacob/vortex/runtime/rtlsim/vortex.cpp:14:
/home/jacob/vortex/runtime/rtlsim/vortex.cpp: In member function ‘int vx_device::mpm_query(uint32_t, uint32_t, uint64_t*)’:
/home/jacob/vortex/runtime/rtlsim/vortex.cpp:235:51: error: invalid use of incomplete type ‘std::unordered_map<unsigned int, std::array<long unsigned int, 32> >::mapped_type’ {aka ‘struct std::array<long unsigned int, 32>’}
  235 |       CHECK_ERR(this->download(mpm_cache_[core_id].data(), mpm_mem_addr, 32 * sizeof(uint64_t)), {