### PR TITLE
Fix use-after-free in mempool

### DIFF
--- a/sim/common/simobject.h
+++ b/sim/common/simobject.h
@@ -176,22 +176,22 @@ public:
   {}
 
   void* operator new(size_t /*size*/) {
-    return allocator().allocate();
+    return allocator_.allocate();
   }
 
   void operator delete(void* ptr) {
-    allocator().deallocate(ptr);
+    allocator_.deallocate(ptr);
   }
 
 protected:
   Func func_;
   Pkt  pkt_;
 
-  static MemoryPool<SimCallEvent<Pkt>>& allocator() {
-    static MemoryPool<SimCallEvent<Pkt>> instance(64);
-    return instance;
-  }
+  static MemoryPool<SimCallEvent<Pkt>> allocator_;
 };
+
+template <typename Pkt>
+MemoryPool<SimCallEvent<Pkt>> SimCallEvent<Pkt>::allocator_(64);
 
 ///////////////////////////////////////////////////////////////////////////////
 
@@ -209,22 +209,22 @@ public:
   {}
 
   void* operator new(size_t /*size*/) {
-    return allocator().allocate();
+    return allocator_.allocate();
   }
 
   void operator delete(void* ptr) {
-    allocator().deallocate(ptr);
+    allocator_.deallocate(ptr);
   }
 
 protected:
   const SimPort<Pkt>* port_; 
   Pkt pkt_;
 
-  static MemoryPool<SimPortEvent<Pkt>>& allocator() {
-    static MemoryPool<SimPortEvent<Pkt>> instance(64);
-    return instance;
-  }
+  static MemoryPool<SimPortEvent<Pkt>> allocator_;
 };
+
+template <typename Pkt>
+MemoryPool<SimPortEvent<Pkt>> SimPortEvent<Pkt>::allocator_(64);
 
 ///////////////////////////////////////////////////////////////////////////////
 


### PR DESCRIPTION
In `sim/common/simobject.h`, the `SimPortEvent` class uses `MemoryPool` to manage its instance allocation as the following code: 

https://github.com/vortexgpgpu/vortex/blob/2e7ab99d28d2164682709d8754bfe26bc3dfae95/sim/common/simobject.h#L211-L226

However, the allocator instance is a static local variable, it may destruct before some instances of `SimPortEvent`. If it happens, the following deletion calls `allocator().deallocate(ptr)` after the allocator's `free_list_` becomes unavailable, therefore a memory error may occur.

<del>To fix this issue, I added an alive flag to `MemoryPool` to mark its lifetime, and check its liveness before push to `free_list_` in `deallocate` method. If the `MemoryPool` itself is already destructed (but not freed if the instance is static or global), this check avoids continue pushing to the dead STL container `free_list_`.</del>

A new approach of fix pushed.