### PR TITLE
Add back the "ecall" and "ebreak" instruction traps for riscv-vector test functionality

### DIFF
--- a/sim/simx/emulator.cpp
+++ b/sim/simx/emulator.cpp
@@ -625,3 +625,15 @@ void Emulator::update_fcrs(uint32_t fflags, uint32_t tid, uint32_t wid) {
     this->set_csr(VX_CSR_FFLAGS, this->get_csr(VX_CSR_FFLAGS, tid, wid) | fflags, tid, wid);
   }
 }
+
+// For riscv-vector test functionality, ecall and ebreak must trap
+// These instructions are used in the vector tests to stop execution of the test
+// Therefore, without these instructions, undefined and incorrect behavior happens
+//
+// For now, we need these instructions to trap for testing the riscv-vector isa
+void Emulator::trigger_ecall() {
+  active_warps_.reset();
+}
+void Emulator::trigger_ebreak() {
+  active_warps_.reset();
+}

--- a/sim/simx/emulator.h
+++ b/sim/simx/emulator.h
@@ -122,6 +122,10 @@ private:
 
   void update_fcrs(uint32_t fflags, uint32_t tid, uint32_t wid);
 
+  void trigger_ecall(); // Re-added for riscv-vector test functionality
+
+  void trigger_ebreak(); // Re-added for riscv-vector test functionality
+
   const Arch& arch_;
   const DCRS& dcrs_;
   Core*       core_;

--- a/sim/simx/execute.cpp
+++ b/sim/simx/execute.cpp
@@ -830,7 +830,11 @@ void Emulator::execute(const Instr &instr, uint32_t wid, instr_trace_t *trace) {
         trace->fetch_stall = true;
         switch (csr_addr) {
         case 0x000: // RV32I: ECALL
+          this->trigger_ecall(); // Re-added for riscv-vector test functionality
+          break;
         case 0x001: // RV32I: EBREAK
+          this->trigger_ebreak(); // Re-added for riscv-vector test functionality
+          break;
         case 0x002: // RV32I: URET
         case 0x102: // RV32I: SRET
         case 0x302: // RV32I: MRET


### PR DESCRIPTION
In commit `f8ef5707780905991f81fbb89ee30d2462c6722d`, the instructions `ecall` and `ebreak` had their trap removed from simx, causing any vector tests that use these instructions to have incorrect and undefined behavior (as the tests would pass over these instructions and continue execution past the intended point).

Therefore, at least for the foreseeable future, the traps for these instructions should be added back so that riscv-vector tests properly execute.