### PR TITLE
fix(tests): correct kernel argument count in basic regression test

### DIFF
--- a/tests/regression/basic/main.cpp
+++ b/tests/regression/basic/main.cpp
@@ -220,7 +220,7 @@ int main(int argc, char *argv[]) {
   RT_CHECK(vx_mem_alloc(device, buf_size, VX_MEM_WRITE, &dst_buffer));
   RT_CHECK(vx_mem_address(dst_buffer, &kernel_arg.dst_addr));
 
-  kernel_arg.count = num_points;
+  kernel_arg.count = count;
 
   std::cout << "dev_src=0x" << std::hex << kernel_arg.src_addr << std::endl;
   std::cout << "dev_dst=0x" << std::hex << kernel_arg.dst_addr << std::endl;


### PR DESCRIPTION
This PR aims to fix memory access violations in the `regression/basic` test, refer to issue #249.

In the kernel of basic tests, we independently schedule operations for each core to execute. In this kernel, we have the following code to calculate the offset:

```C
uint32_t offset  = vx_core_id() * count;
```

However, during testing we passed `num_points` (which is calculated as `count*num_cores`) to `kernel_arg.count`, causing each core to compute out of bounds.

Error message:

> open device connection
number of points: 1024
buffer size: 4096 bytes
allocate device memory
dev_src=0x10000
dev_dst=0x11000
run memcopy test
write source buffer to local memory
read destination buffer from local memory
verify result
upload time: 0 ms
download time: 0 ms
Total elapsed time: 0 ms
run kernel test
upload program
upload kernel argument
start execution
Memory access violation from 0x11000 to 0x11004, curent flags=2, access flags=1
read destination buffer from local memory
verify result
upload time: 0 ms
execute time: 16 ms
download time: 0 ms
Total elapsed time: 16 ms
cleanup
PERF: core0: instrs=-4995072469926809587, cycles=-4995072469926809587, IPC=1.000000
PERF: core1: instrs=-4995072469926809587, cycles=-4995072469926809587, IPC=1.000000
PERF: core2: instrs=-4995072469926809587, cycles=-4995072469926809587, IPC=1.000000
PERF: core3: instrs=-4995072469926809587, cycles=-4995072469926809587, IPC=1.000000
PERF: instrs=-1533545805997686732, cycles=-4995072469926809587, IPC=1.257331
Test PASSED

Test command:
> ./ci/blackbox.sh --cores=4 --app=basic --driver=simx