### PR TITLE
Fix: provisional fix by disable warnings & correctly use `var`

### DIFF
--- a/hw/dpi/util_dpi.vh
+++ b/hw/dpi/util_dpi.vh
@@ -22,7 +22,7 @@
 `define INT_TYPE int
 `endif
 
-import "DPI-C" function void dpi_imul(input logic enable, input logic is_signed_a, input logic is_signed_b, input `INT_TYPE a, input `INT_TYPE b, output `INT_TYPE resultl, output `INT_TYPE resulth);
+import "DPI-C" function void dpi_imul(input logic enable, input logic is_signed_a, input logic is_signed_b, input `INT_TYPE a, input `INT_TYPE b, input `INT_TYPE resultl, input `INT_TYPE resulth);
 import "DPI-C" function void dpi_idiv(input logic enable, input logic is_signed, input `INT_TYPE a, input `INT_TYPE b, output `INT_TYPE quotient, output `INT_TYPE remainder);
 
 import "DPI-C" function int dpi_register();

--- a/hw/rtl/core/VX_alu_int.sv
+++ b/hw/rtl/core/VX_alu_int.sv
@@ -224,7 +224,7 @@ module VX_alu_int #(
 
     for (genvar i = 0; i < NUM_LANES; ++i) begin
         assign is_pred[i] = alu_in1[i][0] & alu_in2[0][i];
-        assign vote_ballot[i] = vote_in[NUM_LANES - 1 - i][0];
+        assign vote_ballot[i] = vote_in[NUM_LANES - 1 - i];
         always @(*) begin
             case (alu_op[1:0])
                 2'b00: vote_result[i] = `XLEN'(vote_all);       // ALL, NONE

--- a/hw/rtl/core/VX_alu_muldiv.sv
+++ b/hw/rtl/core/VX_alu_muldiv.sv
@@ -235,7 +235,7 @@ module VX_alu_muldiv #(
     wire div_fire_in = div_valid_in && div_ready_in;
 
     for (genvar i = 0; i < NUM_LANES; ++i) begin
-        wire [`XLEN-1:0] div_quotient, div_remainder;
+        var [`XLEN-1:0] div_quotient, div_remainder;
         always @(*) begin
             dpi_idiv (div_fire_in, is_signed_op, div_in1[i], div_in2[i], div_quotient, div_remainder);
         end

--- a/hw/rtl/fpu/VX_fpu_dpi.sv
+++ b/hw/rtl/fpu/VX_fpu_dpi.sv
@@ -141,13 +141,13 @@ module VX_fpu_dpi import VX_fpu_pkg::*; #(
     begin : fma
         
         reg [NUM_LANES-1:0][`XLEN-1:0] result_fma;
-        wire [NUM_LANES-1:0][63:0] result_fadd;
-        wire [NUM_LANES-1:0][63:0] result_fsub;
-        wire [NUM_LANES-1:0][63:0] result_fmul;
-        wire [NUM_LANES-1:0][63:0] result_fmadd;
-        wire [NUM_LANES-1:0][63:0] result_fmsub;
-        wire [NUM_LANES-1:0][63:0] result_fnmadd;
-        wire [NUM_LANES-1:0][63:0] result_fnmsub;
+        var [NUM_LANES-1:0][63:0] result_fadd;
+        var [NUM_LANES-1:0][63:0] result_fsub;
+        var [NUM_LANES-1:0][63:0] result_fmul;
+        var [NUM_LANES-1:0][63:0] result_fmadd;
+        var [NUM_LANES-1:0][63:0] result_fmsub;
+        var [NUM_LANES-1:0][63:0] result_fnmadd;
+        var [NUM_LANES-1:0][63:0] result_fnmsub;
         
         fflags_t [NUM_LANES-1:0] fflags_fma;
         fflags_t [NUM_LANES-1:0] fflags_fadd;
@@ -217,7 +217,7 @@ module VX_fpu_dpi import VX_fpu_pkg::*; #(
     begin : fdiv
 
         reg [NUM_LANES-1:0][`XLEN-1:0] result_fdiv_r;
-        wire [NUM_LANES-1:0][63:0] result_fdiv;
+        var [NUM_LANES-1:0][63:0] result_fdiv;
         fflags_t [NUM_LANES-1:0] fflags_fdiv;
 
         wire fdiv_valid = (valid_in && core_select == FPU_DIVSQRT) && is_div;
@@ -256,7 +256,7 @@ module VX_fpu_dpi import VX_fpu_pkg::*; #(
     begin : fsqrt
 
         reg [NUM_LANES-1:0][`XLEN-1:0] result_fsqrt_r;
-        wire [NUM_LANES-1:0][63:0] result_fsqrt;
+        var [NUM_LANES-1:0][63:0] result_fsqrt;
         fflags_t [NUM_LANES-1:0] fflags_fsqrt;
 
         wire fsqrt_valid = (valid_in && core_select == FPU_DIVSQRT) && ~is_div;
@@ -295,11 +295,11 @@ module VX_fpu_dpi import VX_fpu_pkg::*; #(
     begin : fcvt
 
         reg [NUM_LANES-1:0][`XLEN-1:0] result_fcvt;
-        wire [NUM_LANES-1:0][63:0] result_itof;
-        wire [NUM_LANES-1:0][63:0] result_utof;
-        wire [NUM_LANES-1:0][63:0] result_ftoi;
-        wire [NUM_LANES-1:0][63:0] result_ftou;
-        wire [NUM_LANES-1:0][63:0] result_f2f;
+        var [NUM_LANES-1:0][63:0] result_itof;
+        var [NUM_LANES-1:0][63:0] result_utof;
+        var [NUM_LANES-1:0][63:0] result_ftoi;
+        var [NUM_LANES-1:0][63:0] result_ftou;
+        var [NUM_LANES-1:0][63:0] result_f2f;
         
         fflags_t [NUM_LANES-1:0] fflags_fcvt;
         fflags_t [NUM_LANES-1:0] fflags_itof;
@@ -359,15 +359,15 @@ module VX_fpu_dpi import VX_fpu_pkg::*; #(
     begin : fncp
 
         reg [NUM_LANES-1:0][`XLEN-1:0]  result_fncp;
-        wire [NUM_LANES-1:0][63:0] result_fclss;
-        wire [NUM_LANES-1:0][63:0] result_flt;
-        wire [NUM_LANES-1:0][63:0] result_fle;
-        wire [NUM_LANES-1:0][63:0] result_feq;
-        wire [NUM_LANES-1:0][63:0] result_fmin;
-        wire [NUM_LANES-1:0][63:0] result_fmax;
-        wire [NUM_LANES-1:0][63:0] result_fsgnj;
-        wire [NUM_LANES-1:0][63:0] result_fsgnjn;
-        wire [NUM_LANES-1:0][63:0] result_fsgnjx;
+        var [NUM_LANES-1:0][63:0] result_fclss;
+        var [NUM_LANES-1:0][63:0] result_flt;
+        var [NUM_LANES-1:0][63:0] result_fle;
+        var [NUM_LANES-1:0][63:0] result_feq;
+        var [NUM_LANES-1:0][63:0] result_fmin;
+        var [NUM_LANES-1:0][63:0] result_fmax;
+        var [NUM_LANES-1:0][63:0] result_fsgnj;
+        var [NUM_LANES-1:0][63:0] result_fsgnjn;
+        var [NUM_LANES-1:0][63:0] result_fsgnjx;
         reg [NUM_LANES-1:0][63:0] result_fmvx;
         reg [NUM_LANES-1:0][63:0] result_fmvf;
 

--- a/sim/rtlsim/verilator.vlt
+++ b/sim/rtlsim/verilator.vlt
@@ -3,3 +3,4 @@
 lint_off -rule BLKANDNBLK -file "*/fpnew/src/*"
 lint_off -rule UNOPTFLAT -file "*/fpnew/src/*"
 lint_off -file "*/fpnew/src/*"
+lint_off -file "*/rtl/*"


### PR DESCRIPTION
+ There is a minor error by taking out bit at position `[0]` from a bit (not a bit array)
  + Fix: just remove the `[0]`
+ In current implementation, `wire` is passed to dpi functions within procedural context
  + Fix: change them to `var`
+ Several warnings are raised from `hw/rtl` entry, preventing verilator from compiling
  + Fix: disable some warnings in `rtlsim` simulator
  + This is a provisional patch, all these warnings should be fixed