### PR TITLE
Fixing float generator in regression tests

### DIFF
--- a/tests/regression/conv3x/main.cpp
+++ b/tests/regression/conv3x/main.cpp
@@ -50,7 +50,7 @@ public:
   static const char* type_str() {
     return "float";
   }
-  static int generate() {
+  static float generate() {
     return static_cast<float>(rand()) / RAND_MAX;
   }
   static bool compare(float a, float b, int index, int errors) {

--- a/tests/regression/demo/main.cpp
+++ b/tests/regression/demo/main.cpp
@@ -50,7 +50,7 @@ public:
   static const char* type_str() {
     return "float";
   }
-  static int generate() {
+  static float generate() {
     return static_cast<float>(rand()) / RAND_MAX;
   }
   static bool compare(float a, float b, int index, int errors) {

--- a/tests/regression/sgemm2x/main.cpp
+++ b/tests/regression/sgemm2x/main.cpp
@@ -50,7 +50,7 @@ public:
   static const char* type_str() {
     return "float";
   }
-  static int generate() {
+  static float generate() {
     return static_cast<float>(rand()) / RAND_MAX;
   }
   static bool compare(float a, float b, int index, int errors) {

--- a/tests/regression/sgemmx/main.cpp
+++ b/tests/regression/sgemmx/main.cpp
@@ -50,7 +50,7 @@ public:
   static const char* type_str() {
     return "float";
   }
-  static int generate() {
+  static float generate() {
     return static_cast<float>(rand()) / RAND_MAX;
   }
   static bool compare(float a, float b, int index, int errors) {


### PR DESCRIPTION
Previously, this generate function will recast the result of `static_cast<float>(rand()) / RAND_MAX;` back to an `int` because the function is defined as returning an `int`, thus the result will aloways be rounded down to 0 and all genrated data is all 0's.  Thus, correctness is not really checked in this test, because the input is all 0's so it's easy to make the outputs all equal 0 as well.