### PR TITLE
fix: resolve memory access violation in `io_addr` test

### DIFF
--- a/tests/regression/io_addr/main.cpp
+++ b/tests/regression/io_addr/main.cpp
@@ -133,7 +133,7 @@ int main(int argc, char *argv[]) {
   std::cout << "allocate device memory" << std::endl;
   RT_CHECK(vx_mem_alloc(device, addr_buf_size, VX_MEM_READ, &usr_test_buffer));
   RT_CHECK(vx_mem_address(usr_test_buffer, &usr_test_addr));
-  RT_CHECK(vx_mem_reserve(device, io_base_addr, addr_buf_size, VX_MEM_READ, &io_test_buffer));
+  RT_CHECK(vx_mem_reserve(device, io_base_addr, addr_buf_size, VX_MEM_READ_WRITE, &io_test_buffer));
   RT_CHECK(vx_mem_alloc(device, src_buf_size, VX_MEM_READ, &src_buffer));
   RT_CHECK(vx_mem_address(src_buffer, &kernel_arg.src_addr));
   RT_CHECK(vx_mem_alloc(device, dst_buf_size, VX_MEM_WRITE, &dst_buffer));


### PR DESCRIPTION
This PR aims to resolve memory access violation in `io_addr` test.

The `io_addr` regression test was failing with memory access violation errors:

```
Memory access violation from 0x80 to 0x88, curent flags=1, access flags=2
Error: exception: invalid memory address
```

This issue occurs because, during the `io_addr` test, the `io_mpm_addr` is periodically read to obtain test data. In the main test program, this region is reserved with `READ-ONLY` permissions. 

``` c++
  RT_CHECK(vx_mem_alloc(device, addr_buf_size, VX_MEM_READ, &usr_test_buffer));
  RT_CHECK(vx_mem_address(usr_test_buffer, &usr_test_addr));
  RT_CHECK(vx_mem_reserve(device, io_base_addr, addr_buf_size, VX_MEM_READ, &io_test_buffer));
  RT_CHECK(vx_mem_alloc(device, src_buf_size, VX_MEM_READ, &src_buffer));
  RT_CHECK(vx_mem_address(src_buffer, &kernel_arg.src_addr));
  RT_CHECK(vx_mem_alloc(device, dst_buf_size, VX_MEM_WRITE, &dst_buffer));
  RT_CHECK(vx_mem_address(dst_buffer, &kernel_arg.dst_addr));
```


However, at the end of each kernel execution, the program calls `vx_perf_dump` to export performance counters, and `vx_perf_dump` writes the corresponding counter values to `io_mpm_addr`. 

``` asm
.section .text
.type _Exit, @function
.global _Exit
_Exit:
  call vx_perf_dump
  li t0, IO_MPM_EXITCODE
  sw a0, 0(t0)
  fence
  .insn r RISCV_CUSTOM0, 0, 0, x0, x0, x0  # tmc x0
```

``` c++
void vx_perf_dump() {
    int core_id = vx_core_id();
    uint32_t * const csr_mem = (uint32_t*)(IO_MPM_ADDR + 64 * sizeof(uint32_t) * core_id);
    DUMP_CSRS(0);
    //DUMP_CSRS(1); reserved for exitcode
    DUMP_CSRS(2);
    DUMP_CSRS(3);
    ...
}
```

Since the region still has `READ-ONLY` permissions at that point, this results in an error.