### PR TITLE
Fix spurious 'endif' in hw/syn/xilinx/xrt/Makefile

### DIFF
--- a/hw/syn/xilinx/xrt/Makefile
+++ b/hw/syn/xilinx/xrt/Makefile
@@ -100,7 +100,7 @@ ifneq (,$(findstring -DEXT_TCU_ENABLE, $(CONFIGS)))
 	RTL_INCLUDE += -J$(THIRD_PARTY_DIR)/hardfloat/source/RISCV
 	RTL_INCLUDE += -I$(THIRD_PARTY_DIR)/hardfloat/source
 endif
-endif
+
 
 # Kernel compiler global settings
 VPP_FLAGS += --link --target $(TARGET) --platform $(PLATFORM) --save-temps --no_ip_cache


### PR DESCRIPTION
The spurious 'endif' in line 103 results in a fail to build in Rocky Linux 9.2 with XRT 2023.2. Removing the endif solves the issue. 