### PR TITLE
added non zero C matrix for sgemm_tcu

### DIFF
--- a/sim/common/tensor_cfg.h
+++ b/sim/common/tensor_cfg.h
@@ -53,7 +53,7 @@ struct int32 {
 struct int8 {
   using dtype = int8_t;
   static constexpr uint32_t id = 9;
-  static constexpr uint32_t bits = 16;
+  static constexpr uint32_t bits = 8;
   static constexpr const char* name = "i8";
 };
 

--- a/tests/regression/sgemm_tcu/common.h
+++ b/tests/regression/sgemm_tcu/common.h
@@ -22,6 +22,7 @@ typedef struct {
   uint64_t A_addr;
   uint64_t B_addr;
   uint64_t C_addr;
+  uint64_t D_addr;
 } kernel_arg_t;
 
 #endif

--- a/tests/regression/sgemm_tcu/kernel.cpp
+++ b/tests/regression/sgemm_tcu/kernel.cpp
@@ -9,6 +9,7 @@ void kernel_body(kernel_arg_t *__UNIFORM__ arg) {
   auto pA = reinterpret_cast<ctx::input_t *>(arg->A_addr);
   auto pB = reinterpret_cast<ctx::input_t *>(arg->B_addr);
   auto pC = reinterpret_cast<ctx::output_t *>(arg->C_addr);
+  auto pD = reinterpret_cast<ctx::output_t *>(arg->D_addr);
 
   uint32_t M = arg->M;
   uint32_t N = arg->N;
@@ -17,13 +18,13 @@ void kernel_body(kernel_arg_t *__UNIFORM__ arg) {
   ctx::fragment_a   fragA;
   ctx::fragment_b   fragB;
   ctx::fragment_acc fragC;
+  ctx::fragment_acc fragD;
 
   // calculate tile row & column based on block index
   uint32_t tile_row = blockIdx.y * ctx::tileM;
   uint32_t tile_col = blockIdx.x * ctx::tileN;
 
-  // Initialize accumulator tile to zero
-  ctx::fill_fragment(fragC, 0);
+  auto pTileC = pC + tile_row * N + tile_col; 
 
   for (int i = 0; i < K; i += ctx::tileK) {
     auto pTileA = pA + tile_row * K + i;
@@ -41,13 +42,16 @@ void kernel_body(kernel_arg_t *__UNIFORM__ arg) {
       ctx::load_matrix_sync(fragB, pTileB, N);
     }
 
+    // Load C tile
+    ctx::load_matrix_sync(fragC, pTileC, N);
+
     // Matrix multiply-accumulate: c += a * b
-    ctx::mma_sync(fragC, fragA, fragB, fragC);
+    ctx::mma_sync(fragD, fragA, fragB, fragC);
   }
 
   // Store the computed C tile
-  auto pTileC = pC + tile_row * N + tile_col;
-  ctx::store_matrix_sync(pTileC, fragC, N);
+  auto pTileD = pD + tile_row * N + tile_col;
+  ctx::store_matrix_sync(pTileD, fragD, N);
 }
 
 int main() {


### PR DESCRIPTION
Added a non-zero C matrix tile for the sgemm_tcu testbench. Up to this point, the operation was C = A * B. Now the operation at the sgemm_tcu kernel.cpp is D = A * B + C.

Also, I changed sim/common/tensor_cfg.h to make the number of bits match the int8_t type (8 instead of 16)