### PR TITLE
fix : vx_spawn

### DIFF
--- a/kernel/src/vx_spawn.c
+++ b/kernel/src/vx_spawn.c
@@ -237,7 +237,13 @@ int vx_spawn_threads(uint32_t dimension,
     }
 
     // calculate offsets for group distribution
-    uint32_t group_offset = core_id * total_groups_per_core + MIN(core_id, remaining_groups_per_core);
+    uint32_t group_offset;
+    uint32_t base_groups = num_groups / active_cores;
+    if (core_id < remaining_groups_per_core) {
+      group_offset = core_id * (base_groups + 1);
+    } else {
+      group_offset = remaining_groups_per_core * (base_groups + 1) + (core_id - remaining_groups_per_core) * base_groups;
+    }
 
     // set scheduler arguments
     wspawn_groups_args_t wspawn_args = {
@@ -296,7 +302,12 @@ int vx_spawn_threads(uint32_t dimension,
     }
 
     // calculate offsets for task distribution
-    uint32_t all_tasks_offset = core_id * tasks_per_core + MIN(core_id, remaining_tasks_per_core);
+    uint32_t all_tasks_offset;
+    if (core_id < remaining_tasks_per_core) {
+      all_tasks_offset = core_id * tasks_per_core;
+    } else {
+      all_tasks_offset = remaining_tasks_per_core * (tasks_per_core + 1) + (core_id - remaining_tasks_per_core) * tasks_per_core;
+    }
     uint32_t remain_tasks_offset = all_tasks_offset + (tasks_per_core - remaining_tasks);
 
     // prepare scheduler arguments

--- a/kernel/src/vx_spawn.c
+++ b/kernel/src/vx_spawn.c
@@ -238,11 +238,10 @@ int vx_spawn_threads(uint32_t dimension,
 
     // calculate offsets for group distribution
     uint32_t group_offset;
-    uint32_t base_groups = num_groups / active_cores;
     if (core_id < remaining_groups_per_core) {
-      group_offset = core_id * (base_groups + 1);
+      group_offset = core_id * total_groups_per_core;
     } else {
-      group_offset = remaining_groups_per_core * (base_groups + 1) + (core_id - remaining_groups_per_core) * base_groups;
+      group_offset = remaining_groups_per_core + core_id * total_groups_per_core;
     }
 
     // set scheduler arguments
@@ -306,7 +305,7 @@ int vx_spawn_threads(uint32_t dimension,
     if (core_id < remaining_tasks_per_core) {
       all_tasks_offset = core_id * tasks_per_core;
     } else {
-      all_tasks_offset = remaining_tasks_per_core * (tasks_per_core + 1) + (core_id - remaining_tasks_per_core) * tasks_per_core;
+      all_tasks_offset = remaining_tasks_per_core + core_id * tasks_per_core;
     }
     uint32_t remain_tasks_offset = all_tasks_offset + (tasks_per_core - remaining_tasks);
 


### PR DESCRIPTION
Hello. I have encountered a bug in vx_spawn. When the number of groups (or tasks) does not divide evenly across active
cores, the old formula produced wrong offsets for cores with
`core_id < remaining`, causing some work items to be skipped and others
to be processed twice.

### Cause of bug

Before computing the offset, `total_groups_per_core` is incremented for
cores that receive an extra group:

```c
if (core_id < remaining_groups_per_core)
    ++total_groups_per_core;
```

The old formula then used this already-mutated variable:

```c
group_offset = core_id * total_groups_per_core + MIN(core_id, remaining);
```

This double-counts the remainder for affected cores. The same bug was
present in the task distribution path (`all_tasks_offset`).

### Example

10 groups, 4 cores → `base = 2`, `remaining = 2`

| Core | old offset | correct offset | groups assigned (old)          |
|------|------------|----------------|-------------------------------|
| 0    | 0          | 0              | [0, 1, 2]                     |
| 1    | **4**      | **3**          | [4, 5, 6] — group 3 skipped  |
| 2    | 6          | 6              | [6, 7] — group 6 duplicate |
| 3    | 8          | 8              | [8, 9]                        |

This pull request fixes this bug.