### PR TITLE
rename __assert to __vortex_assert (fixes debug builds)

### DIFF
--- a/sim/common/simobject.h
+++ b/sim/common/simobject.h
@@ -88,7 +88,7 @@ public:
   {}
 
   void bind(SimPort<Pkt>* sink) {
-    __assert(0 == capacity_, "only virtual ports can be used a link!")
+    __vortex_assert(0 == capacity_, "only virtual ports can be used a link!")
     assert(sink_ == nullptr);
     sink->source_ = this;
     sink_ = sink;
@@ -97,7 +97,7 @@ public:
 
   template <typename U>
   void bind(SimPort<U>* sink) {
-    __assert(0 == capacity_, "only virtual ports can be used a link!")
+    __vortex_assert(0 == capacity_, "only virtual ports can be used a link!")
     assert(sink_ == nullptr);
     sink->source_ = this;
     sink_ = sink;
@@ -108,7 +108,7 @@ public:
 
   template <typename U, typename Converter>
   void bind(SimPort<U>* sink, const Converter& converter) {
-    __assert(0 == capacity_, "only virtual ports can be used a link!")
+    __vortex_assert(0 == capacity_, "only virtual ports can be used a link!")
     assert(sink_ == nullptr);
     sink->source_ = this;
     sink_ = sink;
@@ -154,14 +154,14 @@ public:
   }
 
   const Pkt& front() const {
-    __assert(sink_ == nullptr, "cannot be called on a stub port!")
-    __assert(!this->empty(), "port is empty!");
+    __vortex_assert(sink_ == nullptr, "cannot be called on a stub port!")
+    __vortex_assert(!this->empty(), "port is empty!");
     return queue_.front();
   }
 
   Pkt& front() {
-    __assert(sink_ == nullptr, "cannot be called on a stub port!")
-    __assert(!this->empty(), "port is empty!");
+    __vortex_assert(sink_ == nullptr, "cannot be called on a stub port!")
+    __vortex_assert(!this->empty(), "port is empty!");
     return queue_.front().pkt;
   }
 
@@ -465,7 +465,7 @@ private:
   template <typename Pkt>
   void schedule_push(SimPort<Pkt>* port, const Pkt& pkt, uint64_t delay) {
     if (port->capacity() != 0) {
-      __assert(0 == push_list_.count(port), "cannot enqueue a port multiple times during the same cycle!");
+      __vortex_assert(0 == push_list_.count(port), "cannot enqueue a port multiple times during the same cycle!");
       push_list_.push_back(port);
     }
     // schedule update event
@@ -481,7 +481,7 @@ private:
 
   template <typename Pkt>
   void schedule_pop(SimPort<Pkt>* port) {
-    __assert(0 == pop_list_.count(port), "cannot dequeue a port multiple times during the same cycle!");
+    __vortex_assert(0 == pop_list_.count(port), "cannot dequeue a port multiple times during the same cycle!");
     pop_list_.push_back(port);
   }
 
@@ -534,15 +534,15 @@ private:
 
 template <typename Pkt>
 void SimPort<Pkt>::push(const Pkt& pkt, uint64_t delay) {
-  __assert(source_ == nullptr, "cannot be called on a sink port!")
-  __assert(!this->full(), "port is full!");
+  __vortex_assert(source_ == nullptr, "cannot be called on a sink port!")
+  __vortex_assert(!this->full(), "port is full!");
   SimPlatform::instance().schedule_push(this, pkt, delay);
 }
 
 template <typename Pkt>
 uint64_t SimPort<Pkt>::pop() {
-  __assert(sink_ == nullptr, "cannot be called on a stub port!")
-  __assert(!this->empty(), "port is empty!");
+  __vortex_assert(sink_ == nullptr, "cannot be called on a stub port!")
+  __vortex_assert(!this->empty(), "port is empty!");
   SimPlatform::instance().schedule_pop(this);
   return queue_.front().cycles;
 }

--- a/sim/common/util.h
+++ b/sim/common/util.h
@@ -30,7 +30,7 @@ void unused(Args &&...) {}
 
 #define __unused(...) unused(__VA_ARGS__)
 
-#define __assert(cond, msg)                           \
+#define __vortex_assert(cond, msg)                           \
   if (!(cond)) {                                      \
     std::cerr << "Assertion failed: " << msg << "\n"; \
     std::cerr << "File: " << __FILE__ << "\n";        \


### PR DESCRIPTION
An extern __assert function is defined in assert.h, which breaks with vortex's macro. Renaming the macro fixes compilation of debug builds.

Tested with `gcc (GCC) 15.2.1 20260123 (Red Hat 15.2.1-7)`.

Error without the patch:
```
➜  build git:(master) ✗ ./ci/blackbox.sh --clusters=1 --cores=4 --warps=4 --threads=4 --driver=rtlsim --app=basic --debug=1
CONFIGS=-DNUM_CLUSTERS=1 -DNUM_CORES=4 -DNUM_WARPS=4 -DNUM_THREADS=4
Running: DEBUG=1 CONFIGS="-DNUM_CLUSTERS=1 -DNUM_CORES=4 -DNUM_WARPS=4 -DNUM_THREADS=4" make -C ./ci/../runtime/rtlsim > /dev/null
In file included from /usr/include/c++/15/cassert:46,
                 from /opt/vortex-tools/verilator/share/verilator/include/verilated.h:50,
                 from /opt/vortex-tools/verilator/share/verilator/include/verilated_vpi.h:29,
                 from /home/nara/vortex/hw/dpi/float_dpi.cpp:23:
/usr/include/assert.h:79:78: error: macro ‘__assert’ passed 3 arguments, but takes just 2
   79 | extern void __assert (const char *__assertion, const char *__file, int __line)
      |                                                                              ^
compilation terminated due to -Wfatal-errors.
make[2]: *** [Vrtlsim_shim.mk:74: float_dpi.o] Error 1
make[2]: *** Waiting for unfinished jobs....
%Error: make -C /home/nara/vortex/build/runtime/rtlsim/../librtlsim.so.obj_dir -f Vrtlsim_shim.mk -j 12 exited with 2
%Error: Command Failed ulimit -s unlimited 2>/dev/null; exec /opt/vortex-tools/verilator/share/verilator/bin/verilator_bin --build --exe --language 1800-2009 --assert -Wall -Wpedantic -Wno-DECLFILENAME -Wno-REDEFMACRO --x-initial unique --x-assign unique verilator.vlt -DSIMULATION -DSV_DPI -DXLEN_64 -DNUM_CLUSTERS=1 -DNUM_CORES=4 -DNUM_WARPS=4 -DNUM_THREADS=4 -I/home/nara/vortex/sim/rtlsim -I/home/nara/vortex/hw/rtl -I/home/nara/vortex/hw/dpi -I/home/nara/vortex/hw/rtl/libs -I/home/nara/vortex/hw/rtl/interfaces -I/home/nara/vortex/hw/rtl/core -I/home/nara/vortex/hw/rtl/mem -I/home/nara/vortex/hw/rtl/cache -I/home/nara/vortex/hw/rtl/fpu /home/nara/vortex/hw/rtl/VX_gpu_pkg.sv /home/nara/vortex/hw/rtl/fpu/VX_fpu_pkg.sv /home/nara/vortex/hw/rtl/VX_trace_pkg.sv --cc rtlsim_shim --top-module rtlsim_shim -j 12 --trace --trace-structs -DDEBUG_LEVEL=1 -DVCD_OUTPUT -DDBG_TRACE_PIPELINE -DDBG_TRACE_MEM -DDBG_TRACE_CACHE -DDBG_TRACE_AFU -DDBG_TRACE_SCOPE -DDBG_TRACE_GBAR -DDBG_TRACE_TCU /home/nara/vortex/sim/common/util.cpp /home/nara/vortex/sim/common/mem.cpp /home/nara/vortex/sim/common/softfloat_ext.cpp /home/nara/vortex/sim/common/rvfloats.cpp /home/nara/vortex/sim/common/dram_sim.cpp /home/nara/vortex/hw/dpi/util_dpi.cpp /home/nara/vortex/hw/dpi/float_dpi.cpp /home/nara/vortex/sim/rtlsim/processor.cpp -CFLAGS -std=c++17\ -Wall\ -Wextra\ -Wfatal-errors\ -Wno-array-bounds\ -fPIC\ -Wno-maybe-uninitialized\ -I/home/nara/vortex/build/hw\ -I/home/nara/vortex/sim/common\ -I/home/nara/vortex/third_party/softfloat/source/include\ -I/home/nara/vortex/third_party/ramulator/ext/spdlog/include\ -I/home/nara/vortex/third_party/ramulator/ext/yaml-cpp/include\ -I/home/nara/vortex/third_party/ramulator/src\ -DXLEN_64\ -DNUM_CLUSTERS=1\ -DNUM_CORES=4\ -DNUM_WARPS=4\ -DNUM_THREADS=4\ -g\ -O0\ -DDEBUG_LEVEL=1\ -DVCD_OUTPUT\ -DDBG_TRACE_PIPELINE\ -DDBG_TRACE_MEM\ -DDBG_TRACE_CACHE\ -DDBG_TRACE_AFU\ -DDBG_TRACE_SCOPE\ -DDBG_TRACE_GBAR\ -DDBG_TRACE_TCU -LDFLAGS -shared\ /home/nara/vortex/third_party/softfloat/build/Linux-x86_64-GCC/softfloat.a\ -Wl\,-rpath\,/home/nara/vortex/third_party/ramulator\ \ -L/home/nara/vortex/third_party/ramulator\ -lramulator --MMD --Mdir /home/nara/vortex/build/runtime/rtlsim/../librtlsim.so.obj_dir -o /home/nara/vortex/build/runtime/rtlsim/../librtlsim.so
make[1]: *** [Makefile:120: /home/nara/vortex/build/runtime/rtlsim/../librtlsim.so] Error 2
make: *** [Makefile:39: /home/nara/vortex/build/runtime/rtlsim/../librtlsim.so] Error 2
Error building driver: ./ci/../runtime/rtlsim
```

With the patch this error doesn't happen.