### PR TITLE
Fix data race in bss

### DIFF
--- a/kernel/src/vx_start.S
+++ b/kernel/src/vx_start.S
@@ -41,12 +41,6 @@ _start:
   li    t0, 1
   .insn r RISCV_CUSTOM0, 0, 0, x0, t0, x0  # tmc t0
 
-  # clear BSS segment
-  la    a0, _edata
-  la    a2, _end
-  sub   a2, a2, a0
-  li    a1, 0
-  call  memset
 
   # initialize trap vector
   # la t0, trap_entry

--- a/runtime/stub/utils.cpp
+++ b/runtime/stub/utils.cpp
@@ -79,6 +79,15 @@ extern int vx_upload_kernel_bytes(vx_device_h hdevice, const void* content, uint
     return err;
   });
 
+  auto bss_size = runtime_size - bin_size;
+  if (bss_size > 0) {
+    std::vector<uint8_t> zeros(bss_size, 0);
+    CHECK_ERR(vx_copy_to_dev(_hbuffer, zeros.data(), bin_size, bss_size), {
+      vx_mem_free(_hbuffer);
+      return err;
+    });
+  }
+
   *hbuffer = _hbuffer;
 
   return 0;


### PR DESCRIPTION
# Fix: BSS data race in multi-core configuration

Hello, I have encountered a data race in the BSS segment when running kernels on multi-core configurations.
All cores start concurrently from `_start`, and each one was calling `memset` to zero the entire BSS region.
`gridDim` and `blockDim` are BSS globals written by `vx_spawn_threads` on core 0.
A lagging core's memset would overwrite these values after core 0 had already set them,
causing `get_global_size()` to return 0 and kernels to produce wrong results or loop indefinitely.

## Cause of bug

In `kernel/src/vx_start.S`, every core executed:

```asm
la    a0, _edata
la    a2, _end
sub   a2, a2, a0
li    a1, 0
call  memset
```

Since all cores start simultaneously, any core can run this memset after core 0 has already
written `gridDim`/`blockDim` via `vx_spawn_threads`, silently zeroing them.

## Fix

Remove the BSS memset from `_start` entirely.

Move BSS zeroing to the host side in `vx_upload_kernel_bytes`:
`vx_copy_to_dev` uploads the kernel binary (`bin_size` bytes), then explicitly
zeros the remaining BSS region (`runtime_size - bin_size` bytes) before the GPU starts.
This guarantees BSS is cleared exactly once, with no possibility of a race.