### PR TITLE
Optimize xilinx_async_bram_patch.tcl

### DIFF
--- a/hw/scripts/xilinx_async_bram_patch.tcl
+++ b/hw/scripts/xilinx_async_bram_patch.tcl
@@ -79,25 +79,11 @@ proc build_parent_child_map {all_cells} {
   return $parent_child_map
 }
 
-proc find_cell_descendants_recursive {parent_cell parent_child_map} {
-  set descendants {}
-  if {[dict exists $parent_child_map $parent_cell]} {
-    set children [dict get $parent_child_map $parent_cell]
-    foreach child $children {
-      # Add the child to the list
-      lappend descendants $child
-      # Recursively add its descendants
-      set sub_descendants [find_cell_descendants_recursive $child $parent_child_map]
-      lappend descendants {*}$sub_descendants
-    }
-  }
-  return $descendants
-}
-
 proc find_cell_descendants {parent_cell} {
-  set all_cells [get_cells -hierarchical]
-  set parent_child_map [build_parent_child_map $all_cells]
-  return [find_cell_descendants_recursive $parent_cell $parent_child_map]
+  current_instance $parent_cell
+  set descendants [get_cells -hierarchical]
+  current_instance
+  return $descendants
 }
 
 proc find_nested_cells {parent_cell name_match {should_exist 1}} {
@@ -120,7 +106,10 @@ proc find_nested_cells {parent_cell name_match {should_exist 1}} {
 
 proc find_cell_nets {cell name_match {should_exist 1}} {
   set matching_nets {}
-  foreach net [get_nets -hierarchical -filter "PARENT_CELL == $cell"] {
+  current_instance $cell
+  set nets [get_nets -hierarchical -filter "PARENT_CELL == $cell"]
+  current_instance
+  foreach net $nets {
     set name [get_property NAME $net]
     if {[regexp $name_match $name]} {
       lappend matching_nets $net
@@ -144,7 +133,10 @@ proc find_cell_net {cell name_match {should_exist 1}} {
 }
 
 proc get_cell_net {cell name} {
+  current_instance $cell
   set net [get_nets -hierarchical -filter "PARENT_CELL == $cell && NAME == $name"]
+  current_instance
+   
   if {[llength $net] == 0} {
     puts "ERROR: No matching net found for '$cell' matching '$name'."
     exit -1


### PR DESCRIPTION
When running my Synthesis-to-Bitstream flow targeting a u250 FPGA, the runtime can get into the 100's of hours for large configurations. More than 90% of this time is spent running the [xilinx_async_bram_patch.tcl](hw/scripts/xilinx_async_bram_patch.tcl) script. 

This patch reduces the runtime complexity from O(x²) to O(x) by not searching through all cells when finding descendants.
This reduces the worst case runtime by 94% from ~120 hours to ~7 for a 16 core 2 cluster configuration.
<img width="1123" height="593" alt="image" src="https://github.com/user-attachments/assets/0674fc7f-78c3-4b82-be9f-7734e5cac21f" />


I do not have access to working FPGAs to test the generated bitstreams, but I verified my changes by running [this modified version of the script](https://github.com/eirikwitt/vortex/compare/master...eirikwitt:vortex:bram-patching-test) on a wide range of configurations.

NB: This was not tested using Vortex's makefiles, but a modified version of Chipyards makefiles as a part of an attempt to run Vortex using FireSim, so results may vary. 