### PR TITLE
Fix FPU x0 writeback scoreboard

### DIFF
--- a/hw/rtl/fpu/VX_fpu_unit.sv
+++ b/hw/rtl/fpu/VX_fpu_unit.sv
@@ -259,7 +259,9 @@ module VX_fpu_unit import VX_gpu_pkg::*, VX_fpu_pkg::*; #(
             .valid_out (per_block_result_if[block_idx].valid),
             .ready_out (per_block_result_if[block_idx].ready)
         );
-        assign per_block_result_if[block_idx].data.wb = 1'b1;
+        // Avoid writeback to x0, which scoreboard does not reserve.
+        assign per_block_result_if[block_idx].data.wb =
+            fpu_rsp_rd != make_reg_num(REG_TYPE_I, RV_REGS_BITS'(0));
     end
 
     VX_gather_unit #(

--- a/tests/kernel/conform/main.cpp
+++ b/tests/kernel/conform/main.cpp
@@ -28,6 +28,8 @@ int main() {
 
 	errors += test_shfl();
 
+	errors += test_feq_x0_scoreboard();
+
 	if (0 == errors) {
 		PRINTF("Passed!\n");
 	} else {

--- a/tests/kernel/conform/tests.cpp
+++ b/tests/kernel/conform/tests.cpp
@@ -31,6 +31,28 @@ int __attribute__((noinline)) make_full_tmask(int num_threads) {
 
 ///////////////////////////////////////////////////////////////////////////////
 
+void __attribute__((noinline)) do_feq_x0_scoreboard() {
+	asm volatile(
+		"fsgnj.s f24, f0, f0\n"
+		"fsgnj.s f1, f0, f0\n"
+		"feq.s x0, f24, f1\n"
+		:
+		:
+		: "memory");
+}
+
+int test_feq_x0_scoreboard() {
+	PRINTF("FEQ x0 Scoreboard Test\n");
+	int num_threads = std::min(vx_num_threads(), 4);
+	int tmask = make_full_tmask(num_threads);
+	vx_tmc(tmask);
+	do_feq_x0_scoreboard();
+	vx_tmc_one();
+	return 0;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+
 #define GLOBAL_MEM_SZ 8
 int global_buffer[GLOBAL_MEM_SZ];
 

--- a/tests/kernel/conform/tests.h
+++ b/tests/kernel/conform/tests.h
@@ -3,6 +3,8 @@
 
 #define PRINTF vx_printf
 
+int test_feq_x0_scoreboard();
+
 int test_global_memory();
 
 int test_local_memory();


### PR DESCRIPTION
## Issue

  Fixes `scoreboard invalid writeback register` RTL assertion triggered by FPU compare instructions writing to integer `x0`, for example:

  ```asm
  feq.s x0, f24, f1
  ```
 It reports:
  ```
9503: *** cluster0-socket0-core0-issue0-scoreboard invalid writeback register: wid=0, PC=0x......., tmask=1110, rd=0 (#126)
- hw/rtl/core/VX_scoreboard.sv:243: Verilog $finish
```

  ## Root Cause

  FPU results always asserted wb, including compare instructions whose destination is integer `x0`.
  The decoder correctly encodes this destination as `make_reg_num(REG_TYPE_I, 0)`, but scoreboard does not reserve `x0`.
  When the FPU later reported a writeback for `x0`, RTL hit the invalid writeback assertion.

  Unless users write (inlined) assembly code, compilers usually do not generate `feq.s x0, ...`, this is not a compiler bug.