### PR TITLE
fix OpenCL test vector/matrix generation

### DIFF
--- a/tests/opencl/sgemm/main.cc
+++ b/tests/opencl/sgemm/main.cc
@@ -64,7 +64,7 @@ public:
   static const char* type_str() {
     return "float";
   }
-  static int generate() {
+  static float generate() {
     return static_cast<float>(rand()) / RAND_MAX;
   }
   static bool compare(float a, float b, int index, int errors) {

--- a/tests/opencl/sgemm2/kernel.cl
+++ b/tests/opencl/sgemm2/kernel.cl
@@ -19,15 +19,15 @@ __kernel void sgemm2(__global TYPE *A,
     // Iterate over blocks
     for (int k = 0; k < N; k += TILE_SIZE) {
         // Load block of matrix A & B to local memory
-        localA[localRow][localCol] = A[globalRow * N + (k + localCol)];
-        localB[localRow][localCol] = B[(k + localRow) * N + globalCol];
+        localA[localRow][localCol] = A[(k + localRow) * N + globalCol];
+        localB[localRow][localCol] = B[globalRow * N + (k + localCol)];
 
         // Ensure the entire block is loaded
         barrier(CLK_LOCAL_MEM_FENCE);
 
         // Compute multiplication for this block
         for (int j = 0; j < TILE_SIZE; j++) {
-            sum += localA[localRow][j] * localB[j][localCol];
+            sum += localA[j][localCol] * localB[localRow][j];
         }
 
         // Ensure computation is done before loading next block

--- a/tests/opencl/sgemm2/main.cc
+++ b/tests/opencl/sgemm2/main.cc
@@ -86,7 +86,7 @@ public:
   static const char* type_str() {
     return "float";
   }
-  static int generate() {
+  static float generate() {
     return static_cast<float>(rand()) / RAND_MAX;
   }
   static bool compare(float a, float b, int index, int errors) {

--- a/tests/opencl/sgemm3/kernel.cl
+++ b/tests/opencl/sgemm3/kernel.cl
@@ -18,15 +18,15 @@ __kernel void sgemm3(__global TYPE *A,
     // Iterate over blocks
     for (int k = 0; k < N; k += localSize) {
         // Load block of matrix A & B to local memory
-        localA[localRow * localSize + localCol] = A[globalRow * N + (k + localCol)];
-        localB[localRow * localSize + localCol] = B[(k + localRow) * N + globalCol];
+        localA[localRow * localSize + localCol] = A[(k + localRow) * N + globalCol];
+        localB[localRow * localSize + localCol] = B[globalRow * N + (k + localCol)];
 
         // Synchronize to make sure the tiles are loaded
         barrier(CLK_LOCAL_MEM_FENCE);
 
         // Multiply the two matrix blocks and accumulate result
         for (int j = 0; j < localSize; j++) {
-            sum += localA[localRow * localSize + j] * localB[j * localSize + localCol];
+            sum += localA[j * localSize + localCol] * localB[localRow * localSize + j];
         }
 
         // Ensure computation is done before loading next block

--- a/tests/opencl/sgemm3/main.cc
+++ b/tests/opencl/sgemm3/main.cc
@@ -86,7 +86,7 @@ public:
   static const char* type_str() {
     return "float";
   }
-  static int generate() {
+  static float generate() {
     return static_cast<float>(rand()) / RAND_MAX;
   }
   static bool compare(float a, float b, int index, int errors) {

--- a/tests/opencl/vecadd/main.cc
+++ b/tests/opencl/vecadd/main.cc
@@ -85,7 +85,7 @@ public:
   static const char* type_str() {
     return "float";
   }
-  static int generate() {
+  static float generate() {
     return static_cast<float>(rand()) / RAND_MAX;
   }
   static bool compare(float a, float b, int index, int errors) {


### PR DESCRIPTION
+ float generators compute random value between 0 and 1, which gets truncated to 0 by the int return type and the tests vecadd/sgemm/sgemm2/sgemm3 were operating on just zeroes. This masked an indexing bug in sgemm2/sgemm3