### PR TITLE
dispatch: compute pack-load effective address with a carry-save adder

### DIFF
--- a/hw/rtl/core/VX_dispatcher.sv
+++ b/hw/rtl/core/VX_dispatcher.sv
@@ -90,12 +90,23 @@ module VX_dispatcher import VX_gpu_pkg::*; #(
     wire [1:0] pld_uop_idx = operands_if.data.op_args.lsu.offset[1:0];
 
     for (genvar j = 0; j < `VX_CFG_SIMD_WIDTH; ++j) begin : g_eff_rs1
-        wire [`VX_CFG_XLEN-1:0] stride_off =
-            ({`VX_CFG_XLEN{pld_uop_idx[0]}} & (operands_if.data.rs2_data[j] << 0))
-          + ({`VX_CFG_XLEN{pld_uop_idx[1]}} & (operands_if.data.rs2_data[j] << 1));
-        assign eff_rs1_data[j] = is_pack_lsu
-            ? (operands_if.data.rs1_data[j] + stride_off)
-            :  operands_if.data.rs1_data[j];
+        // eff = rs1 + idx * rs2 is a 3-input add (rs1 + t0 + t1); collapse it with a
+        // 3:2 compressor + one carry add instead of two chained adds.
+        wire [`VX_CFG_XLEN-1:0] t0 = {`VX_CFG_XLEN{pld_uop_idx[0]}} & operands_if.data.rs2_data[j];
+        wire [`VX_CFG_XLEN-1:0] t1 = {`VX_CFG_XLEN{pld_uop_idx[1]}} & (operands_if.data.rs2_data[j] << 1);
+        wire [`VX_CFG_XLEN+1:0] csa_sum, csa_carry;
+        VX_csa_32 #(
+            .N (`VX_CFG_XLEN)
+        ) eff_csa (
+            .a     (operands_if.data.rs1_data[j]),
+            .b     (t0),
+            .c     (t1),
+            .sum   (csa_sum),
+            .carry (csa_carry)
+        );
+        wire [`VX_CFG_XLEN-1:0] eff_addr = csa_sum[`VX_CFG_XLEN-1:0] + csa_carry[`VX_CFG_XLEN-1:0];
+        `UNUSED_VAR ({csa_sum[`VX_CFG_XLEN+1:`VX_CFG_XLEN], csa_carry[`VX_CFG_XLEN+1:`VX_CFG_XLEN]})
+        assign eff_rs1_data[j] = is_pack_lsu ? eff_addr : operands_if.data.rs1_data[j];
     end
 
     always_comb begin


### PR DESCRIPTION
Shortens the dispatch write path for pack-load address generation.

## What
The pack-load effective address `eff = rs1 + idx*rs2` is a 3-input sum (`rs1 + t0 + t1`). It was computed as two chained adds on the operand-to-LSU-buffer path. This replaces them with a 3:2 carry-save compressor (`VX_csa_32`) plus a single carry add — one compressor level + one CARRY8 add instead of two ripple adds.

## Properties
- **Bit-identical** result (`(rs1 + t0 + t1) mod 2^32` is associative).
- **No latency change** (combinational restructure, no added register).
- **No IPC change** (handshake/scheduling untouched).
- Shortens the operand→LSU-buffer write path that feeds the dispatch FIFO.

## Validation
- packld (exercises the pack-load path) and vecadd (non-pack `eff=rs1`) pass on rtlsim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)