### PR TITLE
small tooling issues

### DIFF
--- a/hw/syn/xilinx/xrt/Makefile
+++ b/hw/syn/xilinx/xrt/Makefile
@@ -1,5 +1,7 @@
 ROOT_DIR := $(realpath ../../../..)
 include $(ROOT_DIR)/config.mk
+# tool binaries (VERILATOR for gen_sources.sh) resolved from TOOLDIR, no sourced env needed
+include $(VORTEX_HOME)/hw/syn/common.mk
 
 ifneq ($(findstring Makefile, $(MAKEFILE_LIST)), Makefile)
 help:

--- a/miscs/apptainer/vortex.def
+++ b/miscs/apptainer/vortex.def
@@ -44,7 +44,7 @@ From: ubuntu:22.04
                        openjdk-11-jre-headless libcairo2 librsvg2-2 librsvg2-common \
                        openjdk-11-jre-zero libtheora0 libavcodec58 libcairo-gobject2 \
                        ca-certificates-java libchromaprint1 software-properties-common perl-modules bzip2 \
-                       unzip zlib1g-dev libtinfo5 g++ usbutils pciutils gawk bison gcc make tar python3.9 python3-pip python3-pytest python3-yaml locales zstd uuid-dev ccache \
+                       unzip zlib1g-dev libtinfo5 g++ usbutils pciutils gawk bison gcc make tar python3.9 python3-pip python3-pytest python3-yaml locales zstd uuid-dev ccache libpng-dev libboost-serialization-dev \
                        libboost-filesystem1.74.0 libboost-program-options1.74.0 libboost-system1.74.0 libboost-chrono1.74.0 libboost-thread1.74.0 \
                        environment-modules openmpi-bin libopenmpi-dev || true
 


### PR DESCRIPTION
- `miscs/apptainer/vortex.def` omitted `libpng-dev` and `libboost-serialization-dev`, which `third_party/cocogfx`
  (`png.cpp`, `cgltrace.cpp`) needs; `make software` fails inside a freshly built image.
  `ci/install_dependencies.sh` already installs both.
- `hw/syn/xilinx/xrt/Makefile` never included `hw/syn/common.mk`, so `gen_sources.sh` fell back to a bare
  `verilator` on `PATH` and failed unless a toolchain env was sourced by hand. Every other synthesis Makefile includes it.