### PR TITLE
simx: clear bit 0 of the JALR target address (rebase of #339)

### DIFF
--- a/sim/simx/alu_unit.cpp
+++ b/sim/simx/alu_unit.cpp
@@ -397,7 +397,9 @@ void AluUnit::execute(instr_trace_t* trace) {
 				if (!tmask.test(t)) continue;
 				rd_data[t].i = link_pc;
 			}
-			warp.PC = rs1_data[thread_last].i + offset;
+			// JALR clears bit 0 of the computed target (RISC-V ISA); the RTL
+			// release build drops it implicitly via from_fullPC() truncation.
+			warp.PC = (rs1_data[thread_last].u + offset) & ~Word(1);
 			core_->perf_stats().branches += 1;
 		} break;
 		case BrType::SYS:

--- a/tests/kernel/conform/main.cpp
+++ b/tests/kernel/conform/main.cpp
@@ -29,6 +29,8 @@ int main() {
 	errors += test_shfl();
 	errors += test_qshfl();
 
+	errors += test_jalr();
+
 	if (0 == errors) {
 		PRINTF("Passed!\n");
 	} else {

--- a/tests/kernel/conform/tests.cpp
+++ b/tests/kernel/conform/tests.cpp
@@ -449,3 +449,59 @@ int test_qshfl() {
 
 	return errors;
 }
+
+///////////////////////////////////////////////////////////////////////////////
+
+#define JALR_PASS_VALUE 0x13579bdf
+
+uint32_t __attribute__((noinline)) do_jalr_misaligned() {
+	uint32_t value = 0;
+	asm volatile(
+		// x1 is prepared so that the misaligned decode path can immediately
+		// execute a valid JALR to label 3 and produce a deterministic failure
+		// value instead of aborting in the decoder.
+		"la x1, 3f\n"
+		// 1744 matches the immediate embedded in the overlapped misaligned
+		// instruction below: jalr x0, -1744(x1).
+		"addi x1, x1, 1744\n"
+		"la t0, 1f\n"
+		// Add 1 on purpose. A correct JALR implementation must clear bit 0 and
+		// land at 1f. An incorrect implementation enters at 1f + 1 instead.
+		"addi t0, t0, 1\n"
+		"jalr x0, t0, 0\n"
+		".balign 4\n"
+		"1:\n"
+		// 0x00806713 is a hand-picked overlapped instruction word:
+		// - from the aligned entry at 1f it decodes as: ori x14, x0, 8
+		// - from the misaligned entry at 1f + 1 it decodes as:
+		//   jalr x0, -1744(x1)
+		// That lets both fixed and unfixed builds decode valid instructions
+		// while still producing different results.
+		".4byte 0x00806713\n"
+		// next aligned instruction after the pass-path overlap word
+		".4byte 0x00000093\n"
+		"j 4f\n"
+		"3:\n"
+		// fail signature: JALR did not clear bit 0
+		"li %[value], 0x2468ace0\n"
+		"j 5f\n"
+		"4:\n"
+		// pass signature: JALR correctly cleared bit 0
+		"li %[value], 0x13579bdf\n"
+		"5:\n"
+		: [value] "=r" (value)
+		:
+		: "x1", "t0", "x14");
+	return value;
+}
+
+int test_jalr() {
+	PRINTF("JALR Test\n");
+	vx_tmc_one();
+	uint32_t value = do_jalr_misaligned();
+	if (value != JALR_PASS_VALUE) {
+		PRINTF("*** error: jalr value=0x%x, expected=0x%x\n", value, JALR_PASS_VALUE);
+		return 1;
+	}
+	return 0;
+}

--- a/tests/kernel/conform/tests.h
+++ b/tests/kernel/conform/tests.h
@@ -28,4 +28,6 @@ int test_vote();
 int test_shfl();
 int test_qshfl();
 
+int test_jalr();
+
 #endif


### PR DESCRIPTION
Rebase of #339 by @cassuto onto current master — the original branch predates the 3.0 history rewrite and cannot be updated in place (its fix targeted the retired `sim/simx/execute.cpp`; the JALR execute path now lives in `sim/simx/alu_unit.cpp`).

## What
- Mask bit 0 of the SimX JALR target: `warp.PC = (rs1 + imm) & ~1` (RISC-V ISA requirement).
- Port of the conform test from #339: lands on an intentionally odd JALR target through an overlapped instruction word, so fixed and unfixed builds both decode valid instructions but produce different pass/fail signatures.

## Verification (master @ 1c3403ddb)
- Unfixed simx: conform fails with the bug signature (`value=0x2468ace0`); fixed simx: passes.
- rtlsim (release): passes — release RTL already clears bit 0 implicitly via `from_fullPC()` PC truncation, so this also restores SimX↔RTL parity.
- Full `tests/regression` simx suite: 81/81 pass with the fix applied.

## Why CI never caught it
Only hand-written assembly can produce a misaligned JALR target (compilers never emit one), and no test exercised it. The conform test added here runs in CI via the kernel category (`kernel.yaml`: simx + rtlsim, both XLENs), closing the hole.

Commit is authored by @cassuto; closes #339.

🤖 Generated with [Claude Code](https://claude.com/claude-code)