### PR TITLE
fpu: carry the decoded wb through the tag store (rebase of #356)

### DIFF
--- a/hw/rtl/fpu/VX_fpu_unit.sv
+++ b/hw/rtl/fpu/VX_fpu_unit.sv
@@ -61,16 +61,16 @@ module VX_fpu_unit import VX_gpu_pkg::*, VX_fpu_pkg::*; #(
 
         fpu_header_t fpu_hdr, fpu_hdr_wb, fpu_hdr_store;
 
-        // FPU always writes back, so header.wb is always 1 at dispatch.
+        // Carry the decoded wb through the tag store: FPU compares may target
+        // integer x0 (e.g. feq.s x0, ...), which decode does not reserve in the
+        // scoreboard, so forcing wb=1 on readback would trip the invalid
+        // writeback assertion.
         always_comb begin
-            fpu_hdr_store    = per_block_execute_if[block_idx].data.header;
-            fpu_hdr_store.wb = 1'b0;
+            fpu_hdr_store = per_block_execute_if[block_idx].data.header;
         end
 
-        // Force wb=1 on the readback path.
         always_comb begin
-            fpu_hdr_wb    = fpu_hdr;
-            fpu_hdr_wb.wb = 1'b1;
+            fpu_hdr_wb = fpu_hdr;
         end
 
         wire [TAG_WIDTH-1:0] fpu_req_tag, fpu_rsp_tag;

--- a/tests/kernel/conform/main.cpp
+++ b/tests/kernel/conform/main.cpp
@@ -31,6 +31,8 @@ int main() {
 
 	errors += test_jalr();
 
+	errors += test_feq_x0_scoreboard();
+
 	if (0 == errors) {
 		PRINTF("Passed!\n");
 	} else {

--- a/tests/kernel/conform/tests.cpp
+++ b/tests/kernel/conform/tests.cpp
@@ -505,3 +505,25 @@ int test_jalr() {
 	}
 	return 0;
 }
+
+///////////////////////////////////////////////////////////////////////////////
+
+void __attribute__((noinline)) do_feq_x0_scoreboard() {
+	asm volatile(
+		"fsgnj.s f24, f0, f0\n"
+		"fsgnj.s f1, f0, f0\n"
+		"feq.s x0, f24, f1\n"
+		:
+		:
+		: "memory");
+}
+
+int test_feq_x0_scoreboard() {
+	PRINTF("FEQ x0 Scoreboard Test\n");
+	int num_threads = std::min(vx_num_threads(), 4);
+	int tmask = make_full_tmask(num_threads);
+	vx_tmc(tmask);
+	do_feq_x0_scoreboard();
+	vx_tmc_one();
+	return 0;
+}

--- a/tests/kernel/conform/tests.h
+++ b/tests/kernel/conform/tests.h
@@ -30,4 +30,6 @@ int test_qshfl();
 
 int test_jalr();
 
+int test_feq_x0_scoreboard();
+
 #endif


### PR DESCRIPTION
Rebase of #356 by @cassuto onto current master — the original branch predates the 3.0 history rewrite and cannot be updated in place. Same root cause, simpler fix shape: instead of re-deriving `rd != x0` at the FPU response (the original's approach against the pre-3.0 `per_block_result_if` code), carry decode's `wb` through the tag store — decode already gates `wb` off for x0 (`VX_decode.sv`: `wb = use_regs[RV_RD] && (reg_ids[RV_RD] != 0)`), so the header is the single source of truth.

## What
- `VX_fpu_unit.sv`: store the dispatch header as decoded; drop the `wb=0` store override and the `wb=1` readback override.
- Port of the conform test from #356: `feq.s x0, f24, f1` under a full tmask.

## Verification (master @ d4fd7ee98)
- Unmodified rtlsim: `VX_scoreboard.sv:230: Assertion failed ... invalid writeback register: rd=0` → $stop/abort.
- With this fix: conform suite passes on **simx and rtlsim**.
- fflags behavior unaffected: the `fpu_csr_tmp_if` path is independent of `wb`, and commit already handles `wb=0` responses (SYS/wctl do routinely).

## Why CI never caught it
Compilers never emit `feq` to x0 (the result would be discarded), so only inline assembly reaches this path, and no test did. The conform test added here runs in CI via the kernel category (simx + rtlsim, both XLENs).

Commit is authored by @cassuto; closes #356.

🤖 Generated with [Claude Code](https://claude.com/claude-code)