### PR TITLE
tests: conform coverage for reserved funct7 decode

### DIFF
--- a/tests/kernel/conform/main.cpp
+++ b/tests/kernel/conform/main.cpp
@@ -33,6 +33,8 @@ int main() {
 
 	errors += test_feq_x0_scoreboard();
 
+	errors += test_reserved_funct7();
+
 	if (0 == errors) {
 		PRINTF("Passed!\n");
 	} else {

--- a/tests/kernel/conform/tests.cpp
+++ b/tests/kernel/conform/tests.cpp
@@ -527,3 +527,23 @@ int test_feq_x0_scoreboard() {
 	vx_tmc_one();
 	return 0;
 }
+
+///////////////////////////////////////////////////////////////////////////////
+
+int test_reserved_funct7() {
+	PRINTF("Reserved funct7 Test\n");
+	vx_tmc_one();
+	// funct7=0x3 is a reserved OP encoding. The RTL decoder's exact funct7
+	// case-match falls through to the base-ALU default (ADD for funct3=0);
+	// SimX must decode it identically instead of treating any odd funct7 as
+	// an M-extension op (which executed this word as MUL).
+	uint32_t a = 7, b = 9, r = 0;
+	asm volatile(".insn r 0x33, 0x0, 0x3, %0, %1, %2"
+	             : "=r"(r)
+	             : "r"(a), "r"(b));
+	if (r != a + b) {
+		PRINTF("*** error: reserved funct7 decode: r=%d, expected=%d\n", r, a + b);
+		return 1;
+	}
+	return 0;
+}

--- a/tests/kernel/conform/tests.h
+++ b/tests/kernel/conform/tests.h
@@ -32,4 +32,6 @@ int test_jalr();
 
 int test_feq_x0_scoreboard();
 
+int test_reserved_funct7();
+
 #endif


### PR DESCRIPTION
Follow-up to #358 (which shipped without a test): a conform test that executes a reserved OP encoding (funct7=0x3, funct3=0) via `.insn` and asserts the RTL-matching base-ALU decode (ADD).

## Validation
- Fixed simx + rtlsim: pass (both decode ADD, r=16).
- With the pre-#358 bug re-introduced locally (`funct7 & 0x1`): the test fails with `r=63` (the word ran as MUL) — verified the check catches exactly the divergence #358 fixed.

Runs in CI via the kernel category (simx + rtlsim, both XLENs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)