### PR TITLE
simx: reject RV32 shift-immediate code points with shamt[5] set

### DIFF
--- a/sim/simx/decompressor.cpp
+++ b/sim/simx/decompressor.cpp
@@ -219,10 +219,20 @@ DecompResult rvc_decompress(uint32_t word) {
             uint32_t subfunct = bits(h, 11, 10);
             if (subfunct == 0b00) { // C.SRLI
                 uint32_t rd_ = rcp(bits(h,9,7));
+#ifndef VX_CFG_XLEN_64
+            // For XLEN=32 shamt[5] must be zero; those code points belong to
+            // custom extensions, not to a shift by 32 or more.
+            if (bit(h, 12)) { out.illegal = true; break; }
+#endif
                 uint32_t sh  = (bit(h,12)<<5) | bits(h,6,2);
                 out.instr32 = ENCI(sh, rd_, 0b101, rd_, 0b0010011);
             } else if (subfunct == 0b01) { // C.SRAI
                 uint32_t rd_ = rcp(bits(h,9,7));
+#ifndef VX_CFG_XLEN_64
+            // For XLEN=32 shamt[5] must be zero; those code points belong to
+            // custom extensions, not to a shift by 32 or more.
+            if (bit(h, 12)) { out.illegal = true; break; }
+#endif
                 uint32_t sh  = (bit(h,12)<<5) | bits(h,6,2);
                 out.instr32 = ENCI(sh, rd_, 0b101, rd_, 0b0010011) | (0x40000000u);
             } else if (subfunct == 0b10) { // C.ANDI
@@ -289,8 +299,13 @@ DecompResult rvc_decompress(uint32_t word) {
         switch (funct3) {
         case 0b000: { // C.SLLI
             uint32_t rd = bits(h, 11, 7);
-            uint32_t sh = (bit(h,12)<<5) | bits(h,6,2);
             if (rd == 0) { out.illegal = true; break; }
+#ifndef VX_CFG_XLEN_64
+            // For XLEN=32 shamt[5] must be zero; those code points belong to
+            // custom extensions, not to a shift by 32 or more.
+            if (bit(h, 12)) { out.illegal = true; break; }
+#endif
+            uint32_t sh = (bit(h,12)<<5) | bits(h,6,2);
             out.instr32 = ENCI(sh, rd, 0b001, rd, 0b0010011);
             break;
         }


### PR DESCRIPTION
The Zca spec reserves `shamt[5]=1` for custom extensions when XLEN=32:

> For XLEN=32, _shamt[5]_ must be zero; the code points with _shamt[5]_=1 are designated for custom extensions.

— stated for `c.slli` and `c.srli`, with `c.srai` defined analogously.

`rvc_decompress` expanded those code points regardless, emitting a 32-bit shift by 32 or more, which is itself an illegal encoding on RV32. This flags them instead, following the guard already used for the RV64-only `c.subw` / `c.addw`.

## Verification

`rvc_decompress` on the three encodings, built for each XLEN:

```
                XLEN=32              XLEN=64
c.slli shamt5=1 illegal              0x02009093
c.srli shamt5=1 illegal              0x02045413
c.srai shamt5=1 illegal              0x42045413
c.slli shamt5=0 0x00409093           0x00409093
```

RV64 and every `shamt[5]=0` encoding are unchanged. `decompressor.cpp` compiles clean under `-Wall -Wextra -Werror` for both XLEN values.
